### PR TITLE
[학생] Student 관련 기초 구조 정의

### DIFF
--- a/src/main/java/com/monari/monariback/global/config/JpaConfig.java
+++ b/src/main/java/com/monari/monariback/global/config/JpaConfig.java
@@ -1,0 +1,9 @@
+package com.monari.monariback.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaConfig {
+}

--- a/src/main/java/com/monari/monariback/student/domain/Student.java
+++ b/src/main/java/com/monari/monariback/student/domain/Student.java
@@ -1,0 +1,47 @@
+package com.monari.monariback.student.domain;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Table(name = "student")
+@Entity
+public class Student {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Integer id;
+
+	@Column(columnDefinition = "BINARY(16)", unique = true, nullable = false, updatable = false)
+	private UUID publicId;
+
+	@Column(length = 255, nullable = false)
+	private String email;
+
+	@Column(length = 100, nullable = false)
+	private String name;
+
+	@Column(length = 50)
+	private String socialProvider;  // 예: KAKAO / NAVER
+
+	@Column(length = 255)
+	private String socialId;
+
+	@Column(length = 20)
+	private String schoolLevel;  // 예: MIDDLE / HIGH
+
+	@Column(length = 20)
+	private String grade;  // 예: ONE / TWO / THREE
+
+	@Column
+	private LocalDateTime createdAt;
+
+	@Column
+	private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/monari/monariback/student/domain/Student.java
+++ b/src/main/java/com/monari/monariback/student/domain/Student.java
@@ -3,8 +3,14 @@ package com.monari.monariback.student.domain;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
+import com.monari.monariback.student.domain.enumerated.Grade;
+import com.monari.monariback.student.domain.enumerated.SchoolLevel;
+import com.monari.monariback.student.domain.enumerated.SocialProvider;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -28,16 +34,19 @@ public class Student {
 	private String name;
 
 	@Column(length = 50)
-	private String socialProvider;  // 예: KAKAO / NAVER
+	@Enumerated(value = EnumType.STRING)
+	private SocialProvider socialProvider;
 
 	@Column(length = 255)
 	private String socialId;
 
 	@Column(length = 20)
-	private String schoolLevel;  // 예: MIDDLE / HIGH
+	@Enumerated(value = EnumType.STRING)
+	private SchoolLevel schoolLevel;
 
 	@Column(length = 20)
-	private String grade;  // 예: ONE / TWO / THREE
+	@Enumerated(value = EnumType.STRING)
+	private Grade grade;
 
 	@Column
 	private LocalDateTime createdAt;

--- a/src/main/java/com/monari/monariback/student/domain/Student.java
+++ b/src/main/java/com/monari/monariback/student/domain/Student.java
@@ -3,6 +3,9 @@ package com.monari.monariback.student.domain;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+
 import com.monari.monariback.student.domain.enumerated.Grade;
 import com.monari.monariback.student.domain.enumerated.SchoolLevel;
 import com.monari.monariback.student.domain.enumerated.SocialProvider;
@@ -48,9 +51,10 @@ public class Student {
 	@Enumerated(value = EnumType.STRING)
 	private Grade grade;
 
-	@Column
+	@CreatedDate
+	@Column(updatable = false)
 	private LocalDateTime createdAt;
 
-	@Column
+	@LastModifiedDate
 	private LocalDateTime updatedAt;
 }

--- a/src/main/java/com/monari/monariback/student/domain/Student.java
+++ b/src/main/java/com/monari/monariback/student/domain/Student.java
@@ -5,6 +5,7 @@ import java.util.UUID;
 
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import com.monari.monariback.student.domain.enumerated.Grade;
 import com.monari.monariback.student.domain.enumerated.SchoolLevel;
@@ -12,6 +13,7 @@ import com.monari.monariback.student.domain.enumerated.SocialProvider;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
@@ -21,6 +23,7 @@ import jakarta.persistence.Table;
 
 @Table(name = "student")
 @Entity
+@EntityListeners(AuditingEntityListener.class)
 public class Student {
 
 	@Id

--- a/src/main/java/com/monari/monariback/student/domain/Student.java
+++ b/src/main/java/com/monari/monariback/student/domain/Student.java
@@ -19,6 +19,7 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
 
 @Table(name = "student")
@@ -60,4 +61,11 @@ public class Student {
 
 	@LastModifiedDate
 	private LocalDateTime updatedAt;
+
+	@PrePersist
+	private void generateUuid() {
+		if (this.publicId == null) {
+			this.publicId = UUID.randomUUID();
+		}
+	}
 }

--- a/src/main/java/com/monari/monariback/student/domain/enumerated/Grade.java
+++ b/src/main/java/com/monari/monariback/student/domain/enumerated/Grade.java
@@ -1,0 +1,7 @@
+package com.monari.monariback.student.domain.enumerated;
+
+public enum Grade {
+	FIRST,
+	SECOND,
+	THIRD
+}

--- a/src/main/java/com/monari/monariback/student/domain/enumerated/SchoolLevel.java
+++ b/src/main/java/com/monari/monariback/student/domain/enumerated/SchoolLevel.java
@@ -1,0 +1,5 @@
+package com.monari.monariback.student.domain.enumerated;
+
+public enum SchoolLevel {
+	MIDDLE, HIGH
+}

--- a/src/main/java/com/monari/monariback/student/domain/enumerated/SocialProvider.java
+++ b/src/main/java/com/monari/monariback/student/domain/enumerated/SocialProvider.java
@@ -1,0 +1,5 @@
+package com.monari.monariback.student.domain.enumerated;
+
+public enum SocialProvider {
+	KAKAO, NAVER
+}

--- a/src/main/java/com/monari/monariback/student/repository/StudentRepository.java
+++ b/src/main/java/com/monari/monariback/student/repository/StudentRepository.java
@@ -1,0 +1,10 @@
+package com.monari.monariback.student.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.monari.monariback.student.domain.Student;
+
+@Repository
+public interface StudentRepository extends JpaRepository<Student, Long> {
+}


### PR DESCRIPTION
## 관련 이슈

> #3 

## 작업 내용
- Student Entity 생성
- 관련 Enum(SchoolLevel, Grade, SocialProvider) 정의
- StudentRepository 인터페이스 정의
- JPA Auditing을 위한 JpaConfig 설정

## ETC
- ERD : public_id 추가, 외부 공개용 ID, UUID v4

내부 DB의 auto-increment id는 노출 시 private한 내용이 노출될 수 있습니다.
UUID는 무작위로 생성되어 외부에 노출해도 안전, JWT의 sub 필드나 외부 API path 등에서 사용하기에 적합합니다.
BINARY(16)은 UUID의 진짜 크기인 16바이트만 사용 → 절반 이하로 최적화 지원됩니다.
| 속성               | 의미                                     |
|--------------------|------------------------------------------|
| `BINARY(16)`       | 저장 공간 최적화, 고성능 UUID 저장 방식 |
| `unique = true`    | UUID 중복 방지                           |
| `nullable = false` | UUID는 반드시 있어야 함                  |
| `updatable = false`| 생성 후 변경 불가 (불변 ID 보장)         |
