### PR TITLE
예외 처리

### DIFF
--- a/src/main/java/com/monari/monariback/global/config/error/ErrorCode.java
+++ b/src/main/java/com/monari/monariback/global/config/error/ErrorCode.java
@@ -1,0 +1,27 @@
+package com.monari.monariback.global.config.error;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum ErrorCode {
+
+    // common
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, "COMMON400", "잘못된 요청입니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "COMMON401", "인증이 필요합니다."),
+    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "COMMON405", "잘못된 HTTP 메서드를 호출했습니다."),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500", "서버 에러가 발생했습니다."),
+
+    // lesson
+    LESSON_NOT_FOUND(HttpStatus.NOT_FOUND, "LESSON4041", "존재하지 않는 수업입니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+
+    ErrorCode(final HttpStatus status, final String code, final String message) {
+        this.status = status;
+        this.code = code;
+        this.message = message;
+    }
+}

--- a/src/main/java/com/monari/monariback/global/config/error/ErrorResponse.java
+++ b/src/main/java/com/monari/monariback/global/config/error/ErrorResponse.java
@@ -1,0 +1,28 @@
+package com.monari.monariback.global.config.error;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ErrorResponse<T> {
+
+    private String code;
+    private String message;
+    private T data;
+
+    public ErrorResponse(final ErrorCode code, final T data) {
+        this.code = code.getCode();
+        this.message = code.getMessage();
+        this.data = data;
+    }
+
+    public static <T> ErrorResponse<T> of(final ErrorCode code, final T data) {
+        return new ErrorResponse<>(code, data);
+    }
+
+    public static ErrorResponse<Void> of(final ErrorCode code) {
+        return new ErrorResponse<>(code, null);
+    }
+}

--- a/src/main/java/com/monari/monariback/global/config/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/monari/monariback/global/config/error/GlobalExceptionHandler.java
@@ -17,7 +17,7 @@ public class GlobalExceptionHandler {
 
     // 지원하지 않는 HTTP method 호출할 경우 발생하는 예외 처리
     @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
-    protected ResponseEntity<ErrorResponse<Void>>  handle(HttpRequestMethodNotSupportedException e) {
+    protected ResponseEntity<ErrorResponse<Void>> handle(HttpRequestMethodNotSupportedException e) {
         log.error("HttpRequestMethodNotSupportedException", e);
         return createErrorResponseEntity(ErrorCode.METHOD_NOT_ALLOWED);
     }
@@ -36,14 +36,14 @@ public class GlobalExceptionHandler {
 
     // 커스텀 비즈니스 예외 처리
     @ExceptionHandler(BusinessException.class)
-    protected ResponseEntity<ErrorResponse<Void>>  handle(BusinessException e) {
+    protected ResponseEntity<ErrorResponse<Void>> handle(BusinessException e) {
         log.error("BusinessException", e);
         return createErrorResponseEntity(e.getErrorCode());
     }
 
     // 그외 예외 처리
     @ExceptionHandler(Exception.class)
-    protected ResponseEntity<ErrorResponse<Void>>  handle(Exception e) {
+    protected ResponseEntity<ErrorResponse<Void>> handle(Exception e) {
         log.error("Exception", e);
         return createErrorResponseEntity(ErrorCode.INTERNAL_SERVER_ERROR);
     }

--- a/src/main/java/com/monari/monariback/global/config/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/monari/monariback/global/config/error/GlobalExceptionHandler.java
@@ -1,0 +1,63 @@
+package com.monari.monariback.global.config.error;
+
+import com.monari.monariback.global.config.error.exception.BusinessException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    // 지원하지 않는 HTTP method 호출할 경우 발생하는 예외 처리
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    protected ResponseEntity<ErrorResponse<Void>>  handle(HttpRequestMethodNotSupportedException e) {
+        log.error("HttpRequestMethodNotSupportedException", e);
+        return createErrorResponseEntity(ErrorCode.METHOD_NOT_ALLOWED);
+    }
+
+    // @Valid 관련 예외 처리
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    protected ResponseEntity<ErrorResponse<Map<String, String>>> handle(MethodArgumentNotValidException e) {
+        log.error("MethodArgumentNotValidException", e);
+
+        Map<String, String> errors = new HashMap<>();
+        e.getBindingResult().getFieldErrors().forEach(
+                error -> errors.put(error.getField(), error.getDefaultMessage()));
+
+        return createErrorResponseEntity(ErrorCode.BAD_REQUEST, errors);
+    }
+
+    // 커스텀 비즈니스 예외 처리
+    @ExceptionHandler(BusinessException.class)
+    protected ResponseEntity<ErrorResponse<Void>>  handle(BusinessException e) {
+        log.error("BusinessException", e);
+        return createErrorResponseEntity(e.getErrorCode());
+    }
+
+    // 그외 예외 처리
+    @ExceptionHandler(Exception.class)
+    protected ResponseEntity<ErrorResponse<Void>>  handle(Exception e) {
+        log.error("Exception", e);
+        return createErrorResponseEntity(ErrorCode.INTERNAL_SERVER_ERROR);
+    }
+
+    private ResponseEntity<ErrorResponse<Void>> createErrorResponseEntity(ErrorCode errorCode) {
+        return new ResponseEntity<>(
+                ErrorResponse.of(errorCode),
+                errorCode.getStatus());
+    }
+
+    private <T> ResponseEntity<ErrorResponse<T>> createErrorResponseEntity(ErrorCode errorCode, T data) {
+        return new ResponseEntity<>(
+                ErrorResponse.of(errorCode, data),
+                errorCode.getStatus());
+    }
+
+}

--- a/src/main/java/com/monari/monariback/global/config/error/exception/BusinessException.java
+++ b/src/main/java/com/monari/monariback/global/config/error/exception/BusinessException.java
@@ -1,0 +1,22 @@
+package com.monari.monariback.global.config.error.exception;
+
+import com.monari.monariback.global.config.error.ErrorCode;
+
+public class BusinessException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public BusinessException(String message, ErrorCode errorCode) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+
+    public BusinessException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public ErrorCode getErrorCode() {
+        return errorCode;
+    }
+}

--- a/src/main/java/com/monari/monariback/global/config/error/exception/NotFoundException.java
+++ b/src/main/java/com/monari/monariback/global/config/error/exception/NotFoundException.java
@@ -1,0 +1,11 @@
+package com.monari.monariback.global.config.error.exception;
+
+import com.monari.monariback.global.config.error.ErrorCode;
+
+public class NotFoundException extends BusinessException {
+
+    public NotFoundException(ErrorCode errorCode) {
+        super(errorCode.getMessage(), errorCode);
+    }
+
+}


### PR DESCRIPTION
## 관련 이슈

> #17 

## 작업 내용
- 커스텀 예외 정의
- 예외 핸들러 정의
- 에러 메시지 객체 정의

## ETC
- ErrorCode 정의 방법: 도메인+HttpStatus+순번
  - ex. LESSON4041 
- 커스텀 예외는 BusinessException을 그대로 사용하거나, BusinessException을 상속 받은 예외 클래스를 이용해서 터뜨리는 방법으로 작성했습니다. 우선 예시로 BusinessException을 상속 받은 NotFoundException을 만들어봤습니다.
`throw new BusinessException(ErrorCode.BAD_REQUEST);` 또는
`throw new NotFoundException(ErrorCode.LESSON_NOT_FOUND);` 

- 커스텀 예외를 하나하나 만들 필요는 없을 것 같고, 중요한 문제만 따로 커스텀 예외를 만들어주면 될 것 같습니다. 위 예시에서도 NotFoundException 예외를 처리해줄 필요가 없다면 따로 만들지 않고 BusinessException 과 같은 상위의 예외를 이용해서 터뜨려도 된다고 생각합니다. 

우선 이렇게 구현해봤는데 다른 의견 있으시면 말씀해주세요!




