### PR TITLE
[인증] JWT 기반 인증 흐름 개선 및 GUEST 사용자 처리 구조 설계

### DIFF
--- a/src/main/java/com/monari/monariback/auth/aop/Auth.java
+++ b/src/main/java/com/monari/monariback/auth/aop/Auth.java
@@ -1,0 +1,11 @@
+package com.monari.monariback.auth.aop;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Auth {
+}

--- a/src/main/java/com/monari/monariback/auth/aop/LoginArgumentResolver.java
+++ b/src/main/java/com/monari/monariback/auth/aop/LoginArgumentResolver.java
@@ -1,0 +1,44 @@
+package com.monari.monariback.auth.aop;
+
+import static com.monari.monariback.auth.constant.JwtConstants.*;
+
+import java.util.UUID;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import com.monari.monariback.auth.entity.Accessor;
+import com.monari.monariback.auth.enumerated.UserType;
+import com.monari.monariback.auth.service.AuthService;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class LoginArgumentResolver implements HandlerMethodArgumentResolver {
+
+	private final AuthService authService;
+
+	@Override
+	public boolean supportsParameter(MethodParameter parameter) {
+		return parameter.hasParameterAnnotation(Auth.class)
+				&& parameter.getParameterType().equals(Accessor.class);
+	}
+
+	@Override
+	public Object resolveArgument(MethodParameter parameter,
+			ModelAndViewContainer mavContainer, NativeWebRequest webRequest,
+			WebDataBinderFactory binderFactory) throws Exception {
+
+		HttpServletRequest request = (HttpServletRequest)webRequest.getNativeRequest();
+		UUID publicId = (UUID)request.getAttribute(REQUEST_ATTR_PUBLIC_ID);
+		UserType userType = (UserType)request.getAttribute(REQUEST_ATTR_USER_TYPE);
+
+		return authService.getCurrentAccessor(publicId, userType);
+	}
+}

--- a/src/main/java/com/monari/monariback/auth/constant/JwtClaimNames.java
+++ b/src/main/java/com/monari/monariback/auth/constant/JwtClaimNames.java
@@ -1,9 +1,0 @@
-package com.monari.monariback.auth.constant;
-
-import lombok.experimental.UtilityClass;
-
-@UtilityClass
-public class JwtClaimNames {
-	public static final String TOKEN_TYPE = "token_type";
-	public static final String USER_TYPE = "user_type";
-}

--- a/src/main/java/com/monari/monariback/auth/constant/JwtConstants.java
+++ b/src/main/java/com/monari/monariback/auth/constant/JwtConstants.java
@@ -14,6 +14,7 @@ public class JwtConstants {
 	public static final String BEARER_PREFIX = "Bearer ";
 	public static final int BEARER_PREFIX_LENGTH = BEARER_PREFIX.length();
 
+	// Request Attribute
 	public static final String REQUEST_ATTR_PUBLIC_ID = "publicId";
 	public static final String REQUEST_ATTR_USER_TYPE = "userType";
 }

--- a/src/main/java/com/monari/monariback/auth/constant/JwtConstants.java
+++ b/src/main/java/com/monari/monariback/auth/constant/JwtConstants.java
@@ -1,0 +1,19 @@
+package com.monari.monariback.auth.constant;
+
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class JwtConstants {
+
+	// ClaimNames
+	public static final String TOKEN_TYPE = "token_type";
+	public static final String USER_TYPE = "user_type";
+
+	// JwtInterceptor
+	public static final String AUTHORIZATION_HEADER = "Authorization";
+	public static final String BEARER_PREFIX = "Bearer ";
+	public static final int BEARER_PREFIX_LENGTH = BEARER_PREFIX.length();
+
+	public static final String REQUEST_ATTR_PUBLIC_ID = "publicId";
+	public static final String REQUEST_ATTR_USER_TYPE = "userType";
+}

--- a/src/main/java/com/monari/monariback/auth/controller/AuthController.java
+++ b/src/main/java/com/monari/monariback/auth/controller/AuthController.java
@@ -26,7 +26,9 @@ public class AuthController {
 			@RequestBody OauthLoginRequest request
 	) {
 		return ResponseEntity.ok().body(
-				OauthLoginResponse.of(authService.login(request))
+				OauthLoginResponse.of(
+						authService.login(request), request.userType()
+				)
 		);
 	}
 }

--- a/src/main/java/com/monari/monariback/auth/dto/response/OauthLoginResponse.java
+++ b/src/main/java/com/monari/monariback/auth/dto/response/OauthLoginResponse.java
@@ -1,11 +1,13 @@
 package com.monari.monariback.auth.dto.response;
 
 import com.monari.monariback.auth.dto.AuthTokenDto;
+import com.monari.monariback.auth.enumerated.UserType;
 
 public record OauthLoginResponse(
-		String accessToken
+		String accessToken,
+		UserType userType
 ) {
-	public static OauthLoginResponse of(AuthTokenDto dto) {
-		return new OauthLoginResponse(dto.accessToken());
+	public static OauthLoginResponse of(AuthTokenDto dto, UserType userType) {
+		return new OauthLoginResponse(dto.accessToken(), userType);
 	}
 }

--- a/src/main/java/com/monari/monariback/auth/entity/Accessor.java
+++ b/src/main/java/com/monari/monariback/auth/entity/Accessor.java
@@ -1,0 +1,25 @@
+package com.monari.monariback.auth.entity;
+
+import java.util.UUID;
+
+import com.monari.monariback.auth.enumerated.UserType;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class Accessor {
+
+	private final UUID publicId;
+	private final UserType userType;
+
+	public static Accessor user(UUID publicId, UserType userType) {
+		return new Accessor(publicId, userType);
+	}
+
+	public static Accessor guest() {
+		return new Accessor(null, UserType.GUEST);
+	}
+}

--- a/src/main/java/com/monari/monariback/auth/enumerated/UserType.java
+++ b/src/main/java/com/monari/monariback/auth/enumerated/UserType.java
@@ -1,5 +1,5 @@
 package com.monari.monariback.auth.enumerated;
 
 public enum UserType {
-	STUDENT, TEACHER;
+	STUDENT, TEACHER, GUEST;
 }

--- a/src/main/java/com/monari/monariback/auth/jwt/JwtInterceptor.java
+++ b/src/main/java/com/monari/monariback/auth/jwt/JwtInterceptor.java
@@ -31,7 +31,12 @@ public class JwtInterceptor implements HandlerInterceptor {
 
 		String token = extractToken(request);
 
-		if (token == null || !jwtResolver.isValid(token)) {
+		if (token == null) {
+			setGuestAttributes(request);
+			return true;
+		}
+
+		if (!jwtResolver.isValid(token)) {
 			throw new AuthException(ErrorCode.AUTH_TOKEN_INVALID);
 		}
 
@@ -53,5 +58,9 @@ public class JwtInterceptor implements HandlerInterceptor {
 
 		request.setAttribute(REQUEST_ATTR_PUBLIC_ID, publicId);
 		request.setAttribute(REQUEST_ATTR_USER_TYPE, userType);
+	}
+
+	private void setGuestAttributes(HttpServletRequest request) {
+		request.setAttribute(REQUEST_ATTR_USER_TYPE, UserType.GUEST);
 	}
 }

--- a/src/main/java/com/monari/monariback/auth/jwt/JwtInterceptor.java
+++ b/src/main/java/com/monari/monariback/auth/jwt/JwtInterceptor.java
@@ -1,0 +1,57 @@
+package com.monari.monariback.auth.jwt;
+
+import static com.monari.monariback.auth.constant.JwtConstants.*;
+
+import java.util.UUID;
+
+import org.springframework.lang.NonNull;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import com.monari.monariback.auth.enumerated.UserType;
+import com.monari.monariback.global.config.error.ErrorCode;
+import com.monari.monariback.global.config.error.exception.AuthException;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class JwtInterceptor implements HandlerInterceptor {
+
+	private final JwtResolver jwtResolver;
+
+	@Override
+	public boolean preHandle(
+			@NonNull HttpServletRequest request,
+			@NonNull HttpServletResponse response,
+			@NonNull Object handler
+	) throws Exception {
+
+		String token = extractToken(request);
+
+		if (token == null || !jwtResolver.isValid(token)) {
+			throw new AuthException(ErrorCode.AUTH_TOKEN_INVALID);
+		}
+
+		setUserAttributes(request, token);
+		return true;
+	}
+
+	private String extractToken(HttpServletRequest request) {
+		String header = request.getHeader(AUTHORIZATION_HEADER);
+		if (header == null || !header.startsWith(BEARER_PREFIX)) {
+			return null;
+		}
+		return header.substring(BEARER_PREFIX_LENGTH);
+	}
+
+	private void setUserAttributes(HttpServletRequest request, String token) {
+		UUID publicId = jwtResolver.extractPublicId(token);
+		UserType userType = jwtResolver.extractUserType(token);
+
+		request.setAttribute(REQUEST_ATTR_PUBLIC_ID, publicId);
+		request.setAttribute(REQUEST_ATTR_USER_TYPE, userType);
+	}
+}

--- a/src/main/java/com/monari/monariback/auth/jwt/JwtProvider.java
+++ b/src/main/java/com/monari/monariback/auth/jwt/JwtProvider.java
@@ -1,6 +1,6 @@
 package com.monari.monariback.auth.jwt;
 
-import static com.monari.monariback.auth.constant.JwtClaimNames.*;
+import static com.monari.monariback.auth.constant.JwtConstants.*;
 
 import java.util.Date;
 import java.util.UUID;

--- a/src/main/java/com/monari/monariback/auth/jwt/JwtProvider.java
+++ b/src/main/java/com/monari/monariback/auth/jwt/JwtProvider.java
@@ -49,10 +49,10 @@ public class JwtProvider {
 
 		return Jwts.builder()
 				.setSubject(publicId.toString())
-				.claim(TOKEN_TYPE, userType)
+				.claim(USER_TYPE, userType)
 				.setIssuedAt(now)
 				.setExpiration(expiredDate)
-				.claim(USER_TYPE, tokenType.name())
+				.claim(TOKEN_TYPE, tokenType.name())
 				.signWith(jwtProperties.getSecretKey())
 				.compact();
 	}

--- a/src/main/java/com/monari/monariback/auth/jwt/JwtResolver.java
+++ b/src/main/java/com/monari/monariback/auth/jwt/JwtResolver.java
@@ -1,0 +1,65 @@
+package com.monari.monariback.auth.jwt;
+
+import static com.monari.monariback.auth.constant.JwtClaimNames.*;
+import static com.monari.monariback.global.config.error.ErrorCode.*;
+
+import java.util.UUID;
+
+import org.springframework.stereotype.Component;
+
+import com.monari.monariback.auth.enumerated.TokenType;
+import com.monari.monariback.auth.enumerated.UserType;
+import com.monari.monariback.global.config.error.exception.AuthException;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class JwtResolver {
+
+	private final JwtProperties jwtProperties;
+
+	public boolean isValid(String token) {
+		try {
+			parseClaims(token);
+			return true;
+		} catch (JwtException | IllegalArgumentException e) {
+			return false;
+		}
+	}
+
+	public UUID extractPublicId(String token) {
+		return UUID.fromString(parseClaims(token).getSubject());
+
+	}
+
+	public UserType extractUserType(String token) {
+		String value = parseClaims(token).get(USER_TYPE, String.class);
+		return UserType.valueOf(value);
+	}
+
+	// TODO : 추후 사용
+	public TokenType extractTokenType(String token) {
+		String value = parseClaims(token).get(TOKEN_TYPE, String.class);
+		return TokenType.valueOf(value);
+
+	}
+
+	private Claims parseClaims(String token) {
+		try {
+			return Jwts.parserBuilder()
+					.setSigningKey(jwtProperties.getSecretKey())
+					.build()
+					.parseClaimsJws(token)
+					.getBody();
+		} catch (ExpiredJwtException e) {
+			throw new AuthException(AUTH_TOKEN_EXPIRED);
+		} catch (JwtException | IllegalArgumentException e) {
+			throw new AuthException(AUTH_TOKEN_INVALID);
+		}
+	}
+}

--- a/src/main/java/com/monari/monariback/auth/jwt/JwtResolver.java
+++ b/src/main/java/com/monari/monariback/auth/jwt/JwtResolver.java
@@ -1,6 +1,6 @@
 package com.monari.monariback.auth.jwt;
 
-import static com.monari.monariback.auth.constant.JwtClaimNames.*;
+import static com.monari.monariback.auth.constant.JwtConstants.*;
 import static com.monari.monariback.global.config.error.ErrorCode.*;
 
 import java.util.UUID;
@@ -34,7 +34,6 @@ public class JwtResolver {
 
 	public UUID extractPublicId(String token) {
 		return UUID.fromString(parseClaims(token).getSubject());
-
 	}
 
 	public UserType extractUserType(String token) {
@@ -46,7 +45,6 @@ public class JwtResolver {
 	public TokenType extractTokenType(String token) {
 		String value = parseClaims(token).get(TOKEN_TYPE, String.class);
 		return TokenType.valueOf(value);
-
 	}
 
 	private Claims parseClaims(String token) {

--- a/src/main/java/com/monari/monariback/auth/service/AuthService.java
+++ b/src/main/java/com/monari/monariback/auth/service/AuthService.java
@@ -16,9 +16,9 @@ import com.monari.monariback.auth.oauth.OauthProviders;
 import com.monari.monariback.auth.oauth.userinfo.OauthUserInfo;
 import com.monari.monariback.common.enumerated.SocialProvider;
 import com.monari.monariback.global.config.error.exception.AuthException;
-import com.monari.monariback.student.domain.Student;
+import com.monari.monariback.student.entity.Student;
 import com.monari.monariback.student.repository.StudentRepository;
-import com.monari.monariback.teacher.domain.Teacher;
+import com.monari.monariback.teacher.entity.Teacher;
 import com.monari.monariback.teacher.repository.TeacherRepository;
 
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/monari/monariback/auth/service/AuthService.java
+++ b/src/main/java/com/monari/monariback/auth/service/AuthService.java
@@ -1,15 +1,21 @@
 package com.monari.monariback.auth.service;
 
+import static com.monari.monariback.global.config.error.ErrorCode.*;
+
+import java.util.UUID;
+
 import org.springframework.stereotype.Service;
 
 import com.monari.monariback.auth.dto.AuthTokenDto;
 import com.monari.monariback.auth.dto.request.OauthLoginRequest;
+import com.monari.monariback.auth.entity.Accessor;
 import com.monari.monariback.auth.enumerated.UserType;
 import com.monari.monariback.auth.jwt.JwtProvider;
 import com.monari.monariback.auth.oauth.OauthProvider;
 import com.monari.monariback.auth.oauth.OauthProviders;
 import com.monari.monariback.auth.oauth.userinfo.OauthUserInfo;
 import com.monari.monariback.common.enumerated.SocialProvider;
+import com.monari.monariback.global.config.error.exception.AuthException;
 import com.monari.monariback.student.domain.Student;
 import com.monari.monariback.student.repository.StudentRepository;
 import com.monari.monariback.teacher.domain.Teacher;
@@ -47,6 +53,7 @@ public class AuthService {
 		return switch (userType) {
 			case STUDENT -> studentLoginProcess(userInfo, socialProvider);
 			case TEACHER -> teacherLoginProcess(userInfo, socialProvider);
+			case GUEST -> throw new AuthException(AUTH_NOT_SUPPORTED_USER_TYPE);
 		};
 	}
 
@@ -84,5 +91,25 @@ public class AuthService {
 		return AuthTokenDto.of(
 				jwtProvider.createAccessToken(teacher.getPublicId(), UserType.TEACHER)
 		);
+	}
+
+	public Accessor getCurrentAccessor(UUID publicId, UserType userType) {
+		if (userType == UserType.GUEST) {
+			return Accessor.guest();
+		}
+
+		if (!existsByUserType(publicId, userType)) {
+			throw new AuthException(AUTH_USER_NOT_FOUND);
+		}
+
+		return Accessor.user(publicId, userType);
+	}
+
+	private boolean existsByUserType(UUID publicId, UserType userType) {
+		return switch (userType) {
+			case STUDENT -> studentRepository.existsByPublicId(publicId);
+			case TEACHER -> teacherRepository.existsByPublicId(publicId);
+			default -> false;
+		};
 	}
 }

--- a/src/main/java/com/monari/monariback/enrollment/entity/Enrollment.java
+++ b/src/main/java/com/monari/monariback/enrollment/entity/Enrollment.java
@@ -2,7 +2,7 @@ package com.monari.monariback.enrollment.entity;
 
 import com.monari.monariback.common.entity.BaseEntity;
 import com.monari.monariback.lesson.entity.Lesson;
-import com.monari.monariback.student.domain.Student;
+import com.monari.monariback.student.entity.Student;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;

--- a/src/main/java/com/monari/monariback/enrollment/service/EnrollmentService.java
+++ b/src/main/java/com/monari/monariback/enrollment/service/EnrollmentService.java
@@ -9,7 +9,7 @@ import com.monari.monariback.global.config.error.exception.BusinessException;
 import com.monari.monariback.global.config.error.exception.NotFoundException;
 import com.monari.monariback.lesson.entity.Lesson;
 import com.monari.monariback.lesson.repository.LessonRepository;
-import com.monari.monariback.student.domain.Student;
+import com.monari.monariback.student.entity.Student;
 import com.monari.monariback.student.repository.StudentRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;

--- a/src/main/java/com/monari/monariback/global/config/WebConfig.java
+++ b/src/main/java/com/monari/monariback/global/config/WebConfig.java
@@ -1,15 +1,25 @@
 package com.monari.monariback.global.config;
 
+import java.util.List;
+
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpHeaders;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import com.monari.monariback.auth.aop.LoginArgumentResolver;
+import com.monari.monariback.auth.jwt.JwtInterceptor;
 
 import lombok.RequiredArgsConstructor;
 
 @Configuration
 @RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {
+
+	private final JwtInterceptor jwtInterceptor;
+	private final LoginArgumentResolver loginArgumentResolver;
 
 	@Override
 	public void addCorsMappings(final CorsRegistry registry) {
@@ -19,5 +29,17 @@ public class WebConfig implements WebMvcConfigurer {
 				.allowCredentials(true)
 				.exposedHeaders(HttpHeaders.LOCATION);
 		WebMvcConfigurer.super.addCorsMappings(registry);
+	}
+
+	@Override
+	public void addInterceptors(InterceptorRegistry registry) {
+		registry.addInterceptor(jwtInterceptor)
+				.addPathPatterns("/api/**")
+				.excludePathPatterns("/auth/**"); // 인증 없는 경로 제외
+	}
+
+	@Override
+	public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+		resolvers.add(loginArgumentResolver);
 	}
 }

--- a/src/main/java/com/monari/monariback/global/config/WebConfig.java
+++ b/src/main/java/com/monari/monariback/global/config/WebConfig.java
@@ -35,7 +35,7 @@ public class WebConfig implements WebMvcConfigurer {
 	public void addInterceptors(InterceptorRegistry registry) {
 		registry.addInterceptor(jwtInterceptor)
 				.addPathPatterns("/api/**")
-				.excludePathPatterns("/auth/**"); // 인증 없는 경로 제외
+				.excludePathPatterns("/auth/**");
 	}
 
 	@Override

--- a/src/main/java/com/monari/monariback/global/config/error/ErrorCode.java
+++ b/src/main/java/com/monari/monariback/global/config/error/ErrorCode.java
@@ -13,7 +13,12 @@ public enum ErrorCode {
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500", "서버 에러가 발생했습니다."),
 
     // lesson
-    LESSON_NOT_FOUND(HttpStatus.NOT_FOUND, "LESSON4041", "존재하지 않는 수업입니다.");
+    LESSON_NOT_FOUND(HttpStatus.NOT_FOUND, "LESSON4041", "존재하지 않는 수업입니다."),
+
+    // auth
+    AUTH_TOKEN_EXPIRED(HttpStatus.BAD_REQUEST, "AUTH4001", "토큰이 만료되었습니다."),
+    AUTH_TOKEN_INVALID(HttpStatus.BAD_REQUEST, "AUTH4002", "토큰 정보가 올바르지 않습니다.")
+    ;
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/monari/monariback/global/config/error/ErrorCode.java
+++ b/src/main/java/com/monari/monariback/global/config/error/ErrorCode.java
@@ -1,7 +1,8 @@
 package com.monari.monariback.global.config.error;
 
-import lombok.Getter;
 import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
 
 @Getter
 public enum ErrorCode {
@@ -17,7 +18,9 @@ public enum ErrorCode {
 
     // auth
     AUTH_TOKEN_EXPIRED(HttpStatus.BAD_REQUEST, "AUTH4001", "토큰이 만료되었습니다."),
-    AUTH_TOKEN_INVALID(HttpStatus.BAD_REQUEST, "AUTH4002", "토큰 정보가 올바르지 않습니다.")
+    AUTH_TOKEN_INVALID(HttpStatus.BAD_REQUEST, "AUTH4002", "토큰 정보가 올바르지 않습니다."),
+    AUTH_NOT_SUPPORTED_USER_TYPE(HttpStatus.BAD_REQUEST, "AUTH4003", "지원하지 않는 유저 타입입니다."),
+    AUTH_USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "AUTH4004", "존재하지 않는 유저입니다.")
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/monari/monariback/global/config/error/exception/AuthException.java
+++ b/src/main/java/com/monari/monariback/global/config/error/exception/AuthException.java
@@ -1,0 +1,17 @@
+package com.monari.monariback.global.config.error.exception;
+
+import com.monari.monariback.global.config.error.ErrorCode;
+
+public class AuthException extends RuntimeException {
+
+	private final ErrorCode errorCode;
+
+	public AuthException(ErrorCode errorCode) {
+		super(errorCode.getMessage());
+		this.errorCode = errorCode;
+	}
+
+	public ErrorCode getErrorCode() {
+		return errorCode;
+	}
+}

--- a/src/main/java/com/monari/monariback/student/entity/Student.java
+++ b/src/main/java/com/monari/monariback/student/entity/Student.java
@@ -1,4 +1,4 @@
-package com.monari.monariback.student.domain;
+package com.monari.monariback.student.entity;
 
 import java.util.UUID;
 

--- a/src/main/java/com/monari/monariback/student/repository/StudentRepository.java
+++ b/src/main/java/com/monari/monariback/student/repository/StudentRepository.java
@@ -8,10 +8,10 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
-import com.monari.monariback.student.domain.Student;
+import com.monari.monariback.student.entity.Student;
 
 @Repository
-public interface StudentRepository extends JpaRepository<Student, Long> {
+public interface StudentRepository extends JpaRepository<Student, Integer> {
 	@Query("""
 			select s from Student s
 			WHERE s.socialId = :socialId

--- a/src/main/java/com/monari/monariback/student/repository/StudentRepository.java
+++ b/src/main/java/com/monari/monariback/student/repository/StudentRepository.java
@@ -1,6 +1,7 @@
 package com.monari.monariback.student.repository;
 
 import java.util.Optional;
+import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -16,4 +17,6 @@ public interface StudentRepository extends JpaRepository<Student, Long> {
 			WHERE s.socialId = :socialId
 			""")
 	Optional<Student> findBySocialId(@Param("socialId") String socialId);
+
+	boolean existsByPublicId(UUID publicId);
 }

--- a/src/main/java/com/monari/monariback/teacher/entity/Teacher.java
+++ b/src/main/java/com/monari/monariback/teacher/entity/Teacher.java
@@ -1,4 +1,4 @@
-package com.monari.monariback.teacher.domain;
+package com.monari.monariback.teacher.entity;
 
 import java.util.UUID;
 

--- a/src/main/java/com/monari/monariback/teacher/repository/TeacherRepository.java
+++ b/src/main/java/com/monari/monariback/teacher/repository/TeacherRepository.java
@@ -8,10 +8,10 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
-import com.monari.monariback.teacher.domain.Teacher;
+import com.monari.monariback.teacher.entity.Teacher;
 
 @Repository
-public interface TeacherRepository extends JpaRepository<Teacher, Long> {
+public interface TeacherRepository extends JpaRepository<Teacher, Integer> {
 	@Query("""
 			select t from Teacher t
 			WHERE t.socialId = :socialId

--- a/src/main/java/com/monari/monariback/teacher/repository/TeacherRepository.java
+++ b/src/main/java/com/monari/monariback/teacher/repository/TeacherRepository.java
@@ -1,6 +1,7 @@
 package com.monari.monariback.teacher.repository;
 
 import java.util.Optional;
+import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -16,4 +17,6 @@ public interface TeacherRepository extends JpaRepository<Teacher, Long> {
 			WHERE t.socialId = :socialId
 			""")
 	Optional<Teacher> findBySocialId(@Param("socialId") String socialId);
+
+	boolean existsByPublicId(UUID publicId);
 }


### PR DESCRIPTION
## 관련 이슈

> #25

---

## 작업 내용

- OAuth 로그인 응답에 `userType` 필드 추가 (`student`, `teacher`)
- JWT 발급 시 `publicId`, `userType` Claim 포함
- `JwtResolver` 구현: 토큰 파싱 및 사용자 정보 추출
- `JwtInterceptor` 구현:
  - 요청 헤더에서 JWT 추출 및 검증
  - 사용자 정보(`publicId`, `userType`)를 request attribute에 저장
- `Accessor` 클래스 도입:
  - 인증된 사용자 정보를 담는 객체
  - GUEST 처리 메서드(`Accessor.guest()`) 제공
- `LoginArgumentResolver` 구현:
  - 컨트롤러 진입 시 `Accessor`를 자동 주입
- `WebConfig` 설정:
  - 인터셉터 및 리졸버 등록
- `JwtConstants`를 통해 하드코딩된 문자열 분리


## ETC

[JWT 기반 인증에서 사용자 미존재 시 예외 처리 여부에 대한 설계_회고](https://blog.naver.com/smileman___/223826449561)

![image](https://github.com/user-attachments/assets/73352b5d-9eb8-4e8a-a3ee-1ebc832763d8)
