### PR TITLE
[회원] 사용자 유형 기반 프로필 조회 및 접근 제어 AOP 도입

### DIFF
--- a/src/main/java/com/monari/monariback/auth/aop/OnlyStudent.java
+++ b/src/main/java/com/monari/monariback/auth/aop/OnlyStudent.java
@@ -1,0 +1,12 @@
+package com.monari.monariback.auth.aop;
+
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.RetentionPolicy.*;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+@Target(METHOD)
+@Retention(RUNTIME)
+public @interface OnlyStudent {
+}

--- a/src/main/java/com/monari/monariback/auth/aop/OnlyTeacher.java
+++ b/src/main/java/com/monari/monariback/auth/aop/OnlyTeacher.java
@@ -1,0 +1,12 @@
+package com.monari.monariback.auth.aop;
+
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.RetentionPolicy.*;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+@Target(METHOD)
+@Retention(RUNTIME)
+public @interface OnlyTeacher {
+}

--- a/src/main/java/com/monari/monariback/auth/aop/UserTypeAuthorizationAspect.java
+++ b/src/main/java/com/monari/monariback/auth/aop/UserTypeAuthorizationAspect.java
@@ -1,0 +1,43 @@
+package com.monari.monariback.auth.aop;
+
+import static com.monari.monariback.global.config.error.ErrorCode.*;
+
+import java.util.Arrays;
+import java.util.function.Predicate;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.stereotype.Component;
+
+import com.monari.monariback.auth.entity.Accessor;
+import com.monari.monariback.global.config.error.exception.AuthException;
+
+@Aspect
+@Component
+public class UserTypeAuthorizationAspect {
+
+	@Around("@annotation(com.monari.monariback.auth.aop.OnlyStudent)")
+	public Object authorizeStudent(ProceedingJoinPoint joinPoint) throws Throwable {
+		return authorize(joinPoint, Accessor::isStudent);
+	}
+
+	@Around("@annotation(com.monari.monariback.auth.aop.OnlyTeacher)")
+	public Object authorizeTeacher(ProceedingJoinPoint joinPoint) throws Throwable {
+		return authorize(joinPoint, Accessor::isTeacher);
+	}
+
+	private Object authorize(
+			ProceedingJoinPoint joinPoint,
+			Predicate<Accessor> condition
+	) throws Throwable {
+		Arrays.stream(joinPoint.getArgs())
+				.filter(Accessor.class::isInstance)
+				.map(Accessor.class::cast)
+				.filter(condition)
+				.findFirst()
+				.orElseThrow(() -> new AuthException(AUTH_FORBIDDEN));
+
+		return joinPoint.proceed();
+	}
+}

--- a/src/main/java/com/monari/monariback/auth/entity/Accessor.java
+++ b/src/main/java/com/monari/monariback/auth/entity/Accessor.java
@@ -22,4 +22,12 @@ public class Accessor {
 	public static Accessor guest() {
 		return new Accessor(null, UserType.GUEST);
 	}
+
+	public boolean isStudent() {
+		return userType == UserType.STUDENT;
+	}
+
+	public boolean isTeacher() {
+		return userType == UserType.TEACHER;
+	}
 }

--- a/src/main/java/com/monari/monariback/enrollment/dto/request/EnrollmentCreateRequest.java
+++ b/src/main/java/com/monari/monariback/enrollment/dto/request/EnrollmentCreateRequest.java
@@ -2,7 +2,7 @@ package com.monari.monariback.enrollment.dto.request;
 
 public record EnrollmentCreateRequest(
     // TODO : Jwt 적용
-    Long studentId,
+    Integer studentId,
     Integer lessonId
 ) {
 

--- a/src/main/java/com/monari/monariback/enrollment/repository/EnrollmentRepository.java
+++ b/src/main/java/com/monari/monariback/enrollment/repository/EnrollmentRepository.java
@@ -7,5 +7,5 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface EnrollmentRepository extends JpaRepository<Enrollment, Integer> {
 
-    boolean existsByStudentIdAndLessonId(Long studentId, Integer lessonId);
+    boolean existsByStudentIdAndLessonId(Integer studentId, Integer lessonId);
 }

--- a/src/main/java/com/monari/monariback/global/config/error/ErrorCode.java
+++ b/src/main/java/com/monari/monariback/global/config/error/ErrorCode.java
@@ -26,7 +26,10 @@ public enum ErrorCode {
     AUTH_USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "AUTH4004", "존재하지 않는 유저입니다."),
 
     // enrollment
-    ENROLLMENT_DUPLICATED(HttpStatus.BAD_REQUEST, "ENROLLMENT8001", "중복 참여는 불가능합니다.");
+    ENROLLMENT_DUPLICATED(HttpStatus.BAD_REQUEST, "ENROLLMENT8001", "중복 참여는 불가능합니다."),
+
+    // teacher
+    TEACHER_NOT_FOUND(HttpStatus.NOT_FOUND, "TEACHER4041", "존재하지 않는 선생님입니다");
     private final HttpStatus status;
     private final String code;
     private final String message;

--- a/src/main/java/com/monari/monariback/global/config/error/ErrorCode.java
+++ b/src/main/java/com/monari/monariback/global/config/error/ErrorCode.java
@@ -24,6 +24,7 @@ public enum ErrorCode {
     AUTH_TOKEN_INVALID(HttpStatus.BAD_REQUEST, "AUTH4002", "토큰 정보가 올바르지 않습니다."),
     AUTH_NOT_SUPPORTED_USER_TYPE(HttpStatus.BAD_REQUEST, "AUTH4003", "지원하지 않는 유저 타입입니다."),
     AUTH_USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "AUTH4004", "존재하지 않는 유저입니다."),
+    AUTH_FORBIDDEN(HttpStatus.BAD_REQUEST, "AUTH4005", "해당 리소스에 접근할 권한이 없습니다."),
 
     // enrollment
     ENROLLMENT_DUPLICATED(HttpStatus.BAD_REQUEST, "ENROLLMENT8001", "중복 참여는 불가능합니다."),

--- a/src/main/java/com/monari/monariback/global/config/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/monari/monariback/global/config/error/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.monari.monariback.global.config.error;
 
+import com.monari.monariback.global.config.error.exception.AuthException;
 import com.monari.monariback.global.config.error.exception.BusinessException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -32,6 +33,12 @@ public class GlobalExceptionHandler {
                 error -> errors.put(error.getField(), error.getDefaultMessage()));
 
         return createErrorResponseEntity(ErrorCode.BAD_REQUEST, errors);
+    }
+
+    @ExceptionHandler(AuthException.class)
+    protected ResponseEntity<ErrorResponse<Void>> handleAuthException(AuthException e) {
+        log.error("AuthException", e);
+        return createErrorResponseEntity(e.getErrorCode(), e.getMessage());
     }
 
     // 커스텀 비즈니스 예외 처리

--- a/src/main/java/com/monari/monariback/student/controller/StudentController.java
+++ b/src/main/java/com/monari/monariback/student/controller/StudentController.java
@@ -6,6 +6,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.monari.monariback.auth.aop.Auth;
+import com.monari.monariback.auth.aop.OnlyStudent;
 import com.monari.monariback.auth.entity.Accessor;
 import com.monari.monariback.student.dto.response.StudentResponse;
 import com.monari.monariback.student.service.StudentService;
@@ -19,6 +20,7 @@ public class StudentController {
 
 	private final StudentService studentService;
 
+	@OnlyStudent
 	@GetMapping("/me")
 	public ResponseEntity<StudentResponse> getMyProfile(@Auth Accessor accessor) {
 		return ResponseEntity.ok().body(

--- a/src/main/java/com/monari/monariback/student/controller/StudentController.java
+++ b/src/main/java/com/monari/monariback/student/controller/StudentController.java
@@ -1,0 +1,30 @@
+package com.monari.monariback.student.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.monari.monariback.auth.aop.Auth;
+import com.monari.monariback.auth.entity.Accessor;
+import com.monari.monariback.student.dto.response.StudentResponse;
+import com.monari.monariback.student.service.StudentService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/students")
+public class StudentController {
+
+	private final StudentService studentService;
+
+	@GetMapping("/me")
+	public ResponseEntity<StudentResponse> getMyProfile(@Auth Accessor accessor) {
+		return ResponseEntity.ok().body(
+				StudentResponse.from(
+						studentService.findMyProfile(accessor)
+				)
+		);
+	}
+}

--- a/src/main/java/com/monari/monariback/student/dto/StudentDto.java
+++ b/src/main/java/com/monari/monariback/student/dto/StudentDto.java
@@ -8,14 +8,16 @@ public record StudentDto(
 		String email,
 		String name,
 		SchoolLevel schoolLevel,
-		Grade grade
+		Grade grade,
+		String profileImageUrl
 ) {
 	public static StudentDto from(Student student) {
 		return new StudentDto(
 				student.getEmail(),
 				student.getName(),
 				student.getSchoolLevel(),
-				student.getGrade()
+				student.getGrade(),
+				student.getProfileImageUrl()
 		);
 	}
 }

--- a/src/main/java/com/monari/monariback/student/dto/StudentDto.java
+++ b/src/main/java/com/monari/monariback/student/dto/StudentDto.java
@@ -1,0 +1,21 @@
+package com.monari.monariback.student.dto;
+
+import com.monari.monariback.common.enumerated.Grade;
+import com.monari.monariback.common.enumerated.SchoolLevel;
+import com.monari.monariback.student.entity.Student;
+
+public record StudentDto(
+		String email,
+		String name,
+		SchoolLevel schoolLevel,
+		Grade grade
+) {
+	public static StudentDto from(Student student) {
+		return new StudentDto(
+				student.getEmail(),
+				student.getName(),
+				student.getSchoolLevel(),
+				student.getGrade()
+		);
+	}
+}

--- a/src/main/java/com/monari/monariback/student/dto/StudentDto.java
+++ b/src/main/java/com/monari/monariback/student/dto/StudentDto.java
@@ -1,10 +1,13 @@
 package com.monari.monariback.student.dto;
 
+import java.util.UUID;
+
 import com.monari.monariback.common.enumerated.Grade;
 import com.monari.monariback.common.enumerated.SchoolLevel;
 import com.monari.monariback.student.entity.Student;
 
 public record StudentDto(
+		UUID publicId,
 		String email,
 		String name,
 		SchoolLevel schoolLevel,
@@ -13,6 +16,7 @@ public record StudentDto(
 ) {
 	public static StudentDto from(Student student) {
 		return new StudentDto(
+				student.getPublicId(),
 				student.getEmail(),
 				student.getName(),
 				student.getSchoolLevel(),

--- a/src/main/java/com/monari/monariback/student/dto/response/StudentResponse.java
+++ b/src/main/java/com/monari/monariback/student/dto/response/StudentResponse.java
@@ -1,0 +1,21 @@
+package com.monari.monariback.student.dto.response;
+
+import com.monari.monariback.common.enumerated.Grade;
+import com.monari.monariback.common.enumerated.SchoolLevel;
+import com.monari.monariback.student.dto.StudentDto;
+
+public record StudentResponse(
+		String email,
+		String name,
+		SchoolLevel schoolLevel,
+		Grade grade
+) {
+	public static StudentResponse from(StudentDto studentDto) {
+		return new StudentResponse(
+				studentDto.email(),
+				studentDto.name(),
+				studentDto.schoolLevel(),
+				studentDto.grade()
+		);
+	}
+}

--- a/src/main/java/com/monari/monariback/student/dto/response/StudentResponse.java
+++ b/src/main/java/com/monari/monariback/student/dto/response/StudentResponse.java
@@ -8,14 +8,16 @@ public record StudentResponse(
 		String email,
 		String name,
 		SchoolLevel schoolLevel,
-		Grade grade
+		Grade grade,
+		String profileImageUrl
 ) {
 	public static StudentResponse from(StudentDto studentDto) {
 		return new StudentResponse(
 				studentDto.email(),
 				studentDto.name(),
 				studentDto.schoolLevel(),
-				studentDto.grade()
+				studentDto.grade(),
+				studentDto.profileImageUrl()
 		);
 	}
 }

--- a/src/main/java/com/monari/monariback/student/dto/response/StudentResponse.java
+++ b/src/main/java/com/monari/monariback/student/dto/response/StudentResponse.java
@@ -1,10 +1,13 @@
 package com.monari.monariback.student.dto.response;
 
+import java.util.UUID;
+
 import com.monari.monariback.common.enumerated.Grade;
 import com.monari.monariback.common.enumerated.SchoolLevel;
 import com.monari.monariback.student.dto.StudentDto;
 
 public record StudentResponse(
+		UUID publicId,
 		String email,
 		String name,
 		SchoolLevel schoolLevel,
@@ -13,6 +16,7 @@ public record StudentResponse(
 ) {
 	public static StudentResponse from(StudentDto studentDto) {
 		return new StudentResponse(
+				studentDto.publicId(),
 				studentDto.email(),
 				studentDto.name(),
 				studentDto.schoolLevel(),

--- a/src/main/java/com/monari/monariback/student/entity/Student.java
+++ b/src/main/java/com/monari/monariback/student/entity/Student.java
@@ -54,6 +54,9 @@ public class Student extends BaseEntity {
 	@Enumerated(value = EnumType.STRING)
 	private Grade grade;
 
+	@Column(length = 255)
+	private String profileImageUrl;
+
 	public static Student signUpWithOauth(
 			String email,
 			String name,

--- a/src/main/java/com/monari/monariback/student/repository/StudentRepository.java
+++ b/src/main/java/com/monari/monariback/student/repository/StudentRepository.java
@@ -19,4 +19,10 @@ public interface StudentRepository extends JpaRepository<Student, Integer> {
 	Optional<Student> findBySocialId(@Param("socialId") String socialId);
 
 	boolean existsByPublicId(UUID publicId);
+
+	@Query("""
+			select s from Student s
+			WHERE s.publicId = :publicId
+			""")
+	Optional<Student> findByPublicId(@Param("publicId") UUID publicId);
 }

--- a/src/main/java/com/monari/monariback/student/service/StudentService.java
+++ b/src/main/java/com/monari/monariback/student/service/StudentService.java
@@ -3,6 +3,7 @@ package com.monari.monariback.student.service;
 import static com.monari.monariback.global.config.error.ErrorCode.*;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.monari.monariback.auth.entity.Accessor;
 import com.monari.monariback.global.config.error.exception.NotFoundException;
@@ -17,6 +18,7 @@ public class StudentService {
 
 	private final StudentRepository studentRepository;
 
+	@Transactional(readOnly = true)
 	public StudentDto findMyProfile(Accessor accessor) {
 		return StudentDto.from(
 				studentRepository.findByPublicId(accessor.getPublicId())

--- a/src/main/java/com/monari/monariback/student/service/StudentService.java
+++ b/src/main/java/com/monari/monariback/student/service/StudentService.java
@@ -1,0 +1,26 @@
+package com.monari.monariback.student.service;
+
+import static com.monari.monariback.global.config.error.ErrorCode.*;
+
+import org.springframework.stereotype.Service;
+
+import com.monari.monariback.auth.entity.Accessor;
+import com.monari.monariback.global.config.error.exception.NotFoundException;
+import com.monari.monariback.student.dto.StudentDto;
+import com.monari.monariback.student.repository.StudentRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class StudentService {
+
+	private final StudentRepository studentRepository;
+
+	public StudentDto findMyProfile(Accessor accessor) {
+		return StudentDto.from(
+				studentRepository.findByPublicId(accessor.getPublicId())
+						.orElseThrow(() -> new NotFoundException(STUDENT_NOT_FOUND))
+		);
+	}
+}

--- a/src/main/java/com/monari/monariback/teacher/controller/TeacherController.java
+++ b/src/main/java/com/monari/monariback/teacher/controller/TeacherController.java
@@ -1,0 +1,30 @@
+package com.monari.monariback.teacher.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.monari.monariback.auth.aop.Auth;
+import com.monari.monariback.auth.entity.Accessor;
+import com.monari.monariback.teacher.dto.response.TeacherResponse;
+import com.monari.monariback.teacher.service.TeacherService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/teachers")
+public class TeacherController {
+
+	private final TeacherService teacherService;
+
+	@GetMapping("/me")
+	public ResponseEntity<TeacherResponse> getMyProfile(@Auth Accessor accessor) {
+		return ResponseEntity.ok().body(
+				TeacherResponse.from(
+						teacherService.findMyProfile(accessor)
+				)
+		);
+	}
+}

--- a/src/main/java/com/monari/monariback/teacher/controller/TeacherController.java
+++ b/src/main/java/com/monari/monariback/teacher/controller/TeacherController.java
@@ -6,6 +6,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.monari.monariback.auth.aop.Auth;
+import com.monari.monariback.auth.aop.OnlyTeacher;
 import com.monari.monariback.auth.entity.Accessor;
 import com.monari.monariback.teacher.dto.response.TeacherResponse;
 import com.monari.monariback.teacher.service.TeacherService;
@@ -19,6 +20,7 @@ public class TeacherController {
 
 	private final TeacherService teacherService;
 
+	@OnlyTeacher
 	@GetMapping("/me")
 	public ResponseEntity<TeacherResponse> getMyProfile(@Auth Accessor accessor) {
 		return ResponseEntity.ok().body(

--- a/src/main/java/com/monari/monariback/teacher/dto/TeacherDto.java
+++ b/src/main/java/com/monari/monariback/teacher/dto/TeacherDto.java
@@ -10,7 +10,8 @@ public record TeacherDto(
 		String name,
 		String university,
 		String major,
-		String career
+		String career,
+		String profileImageUrl
 ) {
 	public static TeacherDto from(Teacher teacher) {
 		return new TeacherDto(
@@ -19,7 +20,8 @@ public record TeacherDto(
 				teacher.getName(),
 				teacher.getUniversity(),
 				teacher.getMajor(),
-				teacher.getCareer()
+				teacher.getCareer(),
+				teacher.getProfileImageUrl()
 		);
 	}
 }

--- a/src/main/java/com/monari/monariback/teacher/dto/TeacherDto.java
+++ b/src/main/java/com/monari/monariback/teacher/dto/TeacherDto.java
@@ -1,0 +1,25 @@
+package com.monari.monariback.teacher.dto;
+
+import java.util.UUID;
+
+import com.monari.monariback.teacher.entity.Teacher;
+
+public record TeacherDto(
+		UUID publicID,
+		String email,
+		String name,
+		String university,
+		String major,
+		String career
+) {
+	public static TeacherDto from(Teacher teacher) {
+		return new TeacherDto(
+				teacher.getPublicId(),
+				teacher.getEmail(),
+				teacher.getName(),
+				teacher.getUniversity(),
+				teacher.getMajor(),
+				teacher.getCareer()
+		);
+	}
+}

--- a/src/main/java/com/monari/monariback/teacher/dto/response/TeacherResponse.java
+++ b/src/main/java/com/monari/monariback/teacher/dto/response/TeacherResponse.java
@@ -1,0 +1,25 @@
+package com.monari.monariback.teacher.dto.response;
+
+import java.util.UUID;
+
+import com.monari.monariback.teacher.dto.TeacherDto;
+
+public record TeacherResponse(
+		UUID publicID,
+		String email,
+		String name,
+		String university,
+		String major,
+		String career
+) {
+	public static TeacherResponse from(TeacherDto teacherDto) {
+		return new TeacherResponse(
+				teacherDto.publicID(),
+				teacherDto.email(),
+				teacherDto.name(),
+				teacherDto.university(),
+				teacherDto.major(),
+				teacherDto.career()
+		);
+	}
+}

--- a/src/main/java/com/monari/monariback/teacher/dto/response/TeacherResponse.java
+++ b/src/main/java/com/monari/monariback/teacher/dto/response/TeacherResponse.java
@@ -10,7 +10,8 @@ public record TeacherResponse(
 		String name,
 		String university,
 		String major,
-		String career
+		String career,
+		String profileImageUrl
 ) {
 	public static TeacherResponse from(TeacherDto teacherDto) {
 		return new TeacherResponse(
@@ -19,7 +20,8 @@ public record TeacherResponse(
 				teacherDto.name(),
 				teacherDto.university(),
 				teacherDto.major(),
-				teacherDto.career()
+				teacherDto.career(),
+				teacherDto.profileImageUrl()
 		);
 	}
 }

--- a/src/main/java/com/monari/monariback/teacher/entity/Teacher.java
+++ b/src/main/java/com/monari/monariback/teacher/entity/Teacher.java
@@ -53,6 +53,9 @@ public class Teacher extends BaseEntity {
 	@Column(length = 1000)
 	private String career;
 
+	@Column(length = 255)
+	private String profileImageUrl;
+
 	public static Teacher signUpWithOauth(
 			String email,
 			String name,

--- a/src/main/java/com/monari/monariback/teacher/repository/TeacherRepository.java
+++ b/src/main/java/com/monari/monariback/teacher/repository/TeacherRepository.java
@@ -19,4 +19,10 @@ public interface TeacherRepository extends JpaRepository<Teacher, Integer> {
 	Optional<Teacher> findBySocialId(@Param("socialId") String socialId);
 
 	boolean existsByPublicId(UUID publicId);
+
+	@Query("""
+			select t from Teacher t
+			WHERE t.publicId = :publicId
+			""")
+	Optional<Teacher> findByPublicId(@Param("publicId") UUID publicId);
 }

--- a/src/main/java/com/monari/monariback/teacher/service/TeacherService.java
+++ b/src/main/java/com/monari/monariback/teacher/service/TeacherService.java
@@ -1,0 +1,28 @@
+package com.monari.monariback.teacher.service;
+
+import static com.monari.monariback.global.config.error.ErrorCode.*;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.monari.monariback.auth.entity.Accessor;
+import com.monari.monariback.global.config.error.exception.NotFoundException;
+import com.monari.monariback.teacher.dto.TeacherDto;
+import com.monari.monariback.teacher.repository.TeacherRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class TeacherService {
+
+	private final TeacherRepository teacherRepository;
+
+	@Transactional(readOnly = true)
+	public TeacherDto findMyProfile(Accessor accessor) {
+		return TeacherDto.from(
+				teacherRepository.findByPublicId(accessor.getPublicId())
+						.orElseThrow(() -> new NotFoundException(TEACHER_NOT_FOUND))
+		);
+	}
+}


### PR DESCRIPTION
## 관련 이슈

> #34 

## 작업 내용
- **학생 / 선생님 내 정보 조회 API 개발**
  - `/students/me`, `/teachers/me` 엔드포인트 구현
  - 로그인된 사용자 정보를 기반으로 본인의 프로필 반환

- **AOP 기반 접근 제어 도입**
  - `@OnlyStudent`, `@OnlyTeacher` 어노테이션 정의
  - `UserTypeAuthorizationAspect` AOP로 Accessor의 `userType` 검사 처리

- **Accessor 기반 사용자 유형 분기 로직 추상화**
  - AOP 내 userType 조건 검사 추상화
  - `isStudent()`, `isTeacher()` 등 메서드 활용

- **GlobalExceptionHandler에 AuthException 처리 핸들러 추가**

- **학생 / 선생님 프로필 응답 필드 확장**
  - `Student`, `Teacher` 엔티티에 `profileImageUrl` 필드 추가
  - `StudentDto`, `TeacherDto`에 매핑


## 인증된 사용자 주입 및 접근 제어 어노테이션 사용 예시
### 1. `@Auth`: JWT 기반 인증 사용자 정보 주입

- 컨트롤러 메서드에 `@Auth Accessor accessor`를 선언하면,
  JWT에서 추출된 사용자 정보(`publicId`, `userType`)가 자동으로 주입됩니다.
- `Interceptor`와 `ArgumentResolver`를 통해 동작합니다.
- 인증되지 않은 경우에는 GUEST로 주입됩니다.

```java
@GetMapping("/me")
public ResponseEntity<StudentResponse> getMyProfile(@Auth Accessor accessor) {
    return ResponseEntity.ok(StudentResponse.from(
        studentService.findMyProfile(accessor)
    ));
}
```
다음과 같이 사용할 수 있습니다.
`studentRepository.findByPublicId(accessor.getPublicId()) `

### 2. `@OnlyStudent`, `@OnlyTeacher`: 사용자 유형 기반 접근 제한

- `UserTypeAuthorizationAspect` AOP를 통해 `Accessor` 객체의 `userType`을 검사합니다.
- 지정된 역할이 아닌 경우 `AuthException`이 발생하여 요청이 차단됩니다.
- 역할별로 메서드에 어노테이션만 붙이면 쉽게 접근 제어가 가능합니다.

#### 학생 전용 접근

```java
@OnlyStudent
@GetMapping("/me")
public ResponseEntity<StudentResponse> getMyProfile(@Auth Accessor accessor) {
    return ResponseEntity.ok(StudentResponse.from(
        studentService.findMyProfile(accessor)
    ));
}
```
#### 선생님 전용 접근
```java
@OnlyTeacher
@GetMapping("/me")
public ResponseEntity<TeacherResponse> getMyProfile(@Auth Accessor accessor) {
    return ResponseEntity.ok(TeacherResponse.from(
        teacherService.findMyProfile(accessor)
    ));
}
```

