### PR TITLE
[회원] 사용자 정보 수정 API 개발

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/com/monari/monariback/global/config/error/ErrorCode.java
+++ b/src/main/java/com/monari/monariback/global/config/error/ErrorCode.java
@@ -12,6 +12,8 @@ public enum ErrorCode {
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "COMMON401", "인증이 필요합니다."),
     METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "COMMON405", "잘못된 HTTP 메서드를 호출했습니다."),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500", "서버 에러가 발생했습니다."),
+    MESSAGE_BODY_UNREADABLE(HttpStatus.BAD_REQUEST, "COMMON400", "요청 본문을 읽을 수 없습니다."),
+    INVALID_ENUM_FORMAT(HttpStatus.BAD_REQUEST, "COMMON400", "'%s'은(는) 유효한 %s 값이 아닙니다."),
 
     // lesson
     LESSON_NOT_FOUND(HttpStatus.NOT_FOUND, "LESSON4041", "존재하지 않는 수업입니다."),

--- a/src/main/java/com/monari/monariback/student/constant/StudentValidationConstants.java
+++ b/src/main/java/com/monari/monariback/student/constant/StudentValidationConstants.java
@@ -1,0 +1,9 @@
+package com.monari.monariback.student.constant;
+
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class StudentValidationConstants {
+	public static final int MAX_PROFILE_IMAGE_URL_LENGTH = 500;
+	public static final String PROFILE_IMAGE_URL_LENGTH_MESSAGE = "프로필 이미지 URL은 500자 이하여야 합니다.";
+}

--- a/src/main/java/com/monari/monariback/student/controller/StudentController.java
+++ b/src/main/java/com/monari/monariback/student/controller/StudentController.java
@@ -14,6 +14,7 @@ import com.monari.monariback.student.dto.request.StudentUpdateRequest;
 import com.monari.monariback.student.dto.response.StudentResponse;
 import com.monari.monariback.student.service.StudentService;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -37,7 +38,7 @@ public class StudentController {
 	@PatchMapping("/me")
 	public ResponseEntity<StudentResponse> updateProfile(
 			@Auth Accessor accessor,
-			@RequestBody StudentUpdateRequest request
+			@RequestBody @Valid StudentUpdateRequest request
 	) {
 		return ResponseEntity.ok().body(
 				StudentResponse.from(

--- a/src/main/java/com/monari/monariback/student/controller/StudentController.java
+++ b/src/main/java/com/monari/monariback/student/controller/StudentController.java
@@ -2,12 +2,15 @@ package com.monari.monariback.student.controller;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.monari.monariback.auth.aop.Auth;
 import com.monari.monariback.auth.aop.OnlyStudent;
 import com.monari.monariback.auth.entity.Accessor;
+import com.monari.monariback.student.dto.request.StudentUpdateRequest;
 import com.monari.monariback.student.dto.response.StudentResponse;
 import com.monari.monariback.student.service.StudentService;
 
@@ -26,6 +29,19 @@ public class StudentController {
 		return ResponseEntity.ok().body(
 				StudentResponse.from(
 						studentService.findMyProfile(accessor)
+				)
+		);
+	}
+
+	@OnlyStudent
+	@PatchMapping("/me")
+	public ResponseEntity<StudentResponse> updateProfile(
+			@Auth Accessor accessor,
+			@RequestBody StudentUpdateRequest request
+	) {
+		return ResponseEntity.ok().body(
+				StudentResponse.from(
+						studentService.updateProfile(accessor, request)
 				)
 		);
 	}

--- a/src/main/java/com/monari/monariback/student/dto/request/StudentUpdateRequest.java
+++ b/src/main/java/com/monari/monariback/student/dto/request/StudentUpdateRequest.java
@@ -1,11 +1,18 @@
 package com.monari.monariback.student.dto.request;
 
+import static com.monari.monariback.teacher.constant.TeacherValidationConstants.*;
+
 import com.monari.monariback.common.enumerated.Grade;
 import com.monari.monariback.common.enumerated.SchoolLevel;
 
+import jakarta.validation.constraints.Size;
+
 public record StudentUpdateRequest(
+
 		SchoolLevel schoolLevel,
 		Grade grade,
+
+		@Size(max = MAX_PROFILE_IMAGE_URL_LENGTH, message = PROFILE_IMAGE_URL_LENGTH_MESSAGE)
 		String profileImageUrl
 ) {
 }

--- a/src/main/java/com/monari/monariback/student/dto/request/StudentUpdateRequest.java
+++ b/src/main/java/com/monari/monariback/student/dto/request/StudentUpdateRequest.java
@@ -1,0 +1,11 @@
+package com.monari.monariback.student.dto.request;
+
+import com.monari.monariback.common.enumerated.Grade;
+import com.monari.monariback.common.enumerated.SchoolLevel;
+
+public record StudentUpdateRequest(
+		SchoolLevel schoolLevel,
+		Grade grade,
+		String profileImageUrl
+) {
+}

--- a/src/main/java/com/monari/monariback/student/dto/request/StudentUpdateRequest.java
+++ b/src/main/java/com/monari/monariback/student/dto/request/StudentUpdateRequest.java
@@ -1,6 +1,6 @@
 package com.monari.monariback.student.dto.request;
 
-import static com.monari.monariback.teacher.constant.TeacherValidationConstants.*;
+import static com.monari.monariback.student.constant.StudentValidationConstants.*;
 
 import com.monari.monariback.common.enumerated.Grade;
 import com.monari.monariback.common.enumerated.SchoolLevel;

--- a/src/main/java/com/monari/monariback/student/entity/Student.java
+++ b/src/main/java/com/monari/monariback/student/entity/Student.java
@@ -71,6 +71,17 @@ public class Student extends BaseEntity {
 		return student;
 	}
 
+	public Student updateProfile(
+			SchoolLevel schoolLevel,
+			Grade grade,
+			String profileImageUrl
+	) {
+		this.schoolLevel = schoolLevel;
+		this.grade = grade;
+		this.profileImageUrl = profileImageUrl;
+		return this;
+	}
+
 	@PrePersist
 	private void generateUuid() {
 		if (this.publicId == null) {

--- a/src/main/java/com/monari/monariback/student/service/StudentService.java
+++ b/src/main/java/com/monari/monariback/student/service/StudentService.java
@@ -8,6 +8,8 @@ import org.springframework.transaction.annotation.Transactional;
 import com.monari.monariback.auth.entity.Accessor;
 import com.monari.monariback.global.config.error.exception.NotFoundException;
 import com.monari.monariback.student.dto.StudentDto;
+import com.monari.monariback.student.dto.request.StudentUpdateRequest;
+import com.monari.monariback.student.entity.Student;
 import com.monari.monariback.student.repository.StudentRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -23,6 +25,19 @@ public class StudentService {
 		return StudentDto.from(
 				studentRepository.findByPublicId(accessor.getPublicId())
 						.orElseThrow(() -> new NotFoundException(STUDENT_NOT_FOUND))
+		);
+	}
+
+	@Transactional
+	public StudentDto updateProfile(Accessor accessor, StudentUpdateRequest request) {
+		Student student = studentRepository.findByPublicId(accessor.getPublicId())
+				.orElseThrow(() -> new NotFoundException(STUDENT_NOT_FOUND));
+		return StudentDto.from(
+				student.updateProfile(
+						request.schoolLevel(),
+						request.grade(),
+						request.profileImageUrl()
+				)
 		);
 	}
 }

--- a/src/main/java/com/monari/monariback/teacher/constant/TeacherValidationConstants.java
+++ b/src/main/java/com/monari/monariback/teacher/constant/TeacherValidationConstants.java
@@ -1,0 +1,17 @@
+package com.monari.monariback.teacher.constant;
+
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class TeacherValidationConstants {
+
+	public static final int MAX_UNIVERSITY_LENGTH = 100;
+	public static final int MAX_MAJOR_LENGTH = 100;
+	public static final int MAX_CAREER_LENGTH = 1000;
+	public static final int MAX_PROFILE_IMAGE_URL_LENGTH = 500;
+
+	public static final String UNIVERSITY_LENGTH_MESSAGE = "대학교명은 100자 이하여야 합니다.";
+	public static final String MAJOR_LENGTH_MESSAGE = "전공명은 100자 이하여야 합니다.";
+	public static final String CAREER_LENGTH_MESSAGE = "경력 내용은 1000자 이하여야 합니다.";
+	public static final String PROFILE_IMAGE_URL_LENGTH_MESSAGE = "프로필 이미지 URL은 500자 이하여야 합니다.";
+}

--- a/src/main/java/com/monari/monariback/teacher/controller/TeacherController.java
+++ b/src/main/java/com/monari/monariback/teacher/controller/TeacherController.java
@@ -2,12 +2,15 @@ package com.monari.monariback.teacher.controller;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.monari.monariback.auth.aop.Auth;
 import com.monari.monariback.auth.aop.OnlyTeacher;
 import com.monari.monariback.auth.entity.Accessor;
+import com.monari.monariback.teacher.dto.request.TeacherUpdateRequest;
 import com.monari.monariback.teacher.dto.response.TeacherResponse;
 import com.monari.monariback.teacher.service.TeacherService;
 
@@ -26,6 +29,19 @@ public class TeacherController {
 		return ResponseEntity.ok().body(
 				TeacherResponse.from(
 						teacherService.findMyProfile(accessor)
+				)
+		);
+	}
+
+	@OnlyTeacher
+	@PatchMapping("/me")
+	public ResponseEntity<TeacherResponse> updateProfile(
+			@Auth Accessor accessor,
+			@RequestBody TeacherUpdateRequest request
+	) {
+		return ResponseEntity.ok().body(
+				TeacherResponse.from(
+						teacherService.updateProfile(accessor, request)
 				)
 		);
 	}

--- a/src/main/java/com/monari/monariback/teacher/controller/TeacherController.java
+++ b/src/main/java/com/monari/monariback/teacher/controller/TeacherController.java
@@ -14,6 +14,7 @@ import com.monari.monariback.teacher.dto.request.TeacherUpdateRequest;
 import com.monari.monariback.teacher.dto.response.TeacherResponse;
 import com.monari.monariback.teacher.service.TeacherService;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -37,7 +38,7 @@ public class TeacherController {
 	@PatchMapping("/me")
 	public ResponseEntity<TeacherResponse> updateProfile(
 			@Auth Accessor accessor,
-			@RequestBody TeacherUpdateRequest request
+			@RequestBody @Valid TeacherUpdateRequest request
 	) {
 		return ResponseEntity.ok().body(
 				TeacherResponse.from(

--- a/src/main/java/com/monari/monariback/teacher/dto/request/TeacherUpdateRequest.java
+++ b/src/main/java/com/monari/monariback/teacher/dto/request/TeacherUpdateRequest.java
@@ -1,0 +1,9 @@
+package com.monari.monariback.teacher.dto.request;
+
+public record TeacherUpdateRequest(
+		String university,
+		String major,
+		String career,
+		String profileImageUrl
+) {
+}

--- a/src/main/java/com/monari/monariback/teacher/dto/request/TeacherUpdateRequest.java
+++ b/src/main/java/com/monari/monariback/teacher/dto/request/TeacherUpdateRequest.java
@@ -1,9 +1,20 @@
 package com.monari.monariback.teacher.dto.request;
 
+import static com.monari.monariback.teacher.constant.TeacherValidationConstants.*;
+
+import jakarta.validation.constraints.Size;
+
 public record TeacherUpdateRequest(
+		@Size(max = MAX_UNIVERSITY_LENGTH, message = UNIVERSITY_LENGTH_MESSAGE)
 		String university,
+
+		@Size(max = MAX_MAJOR_LENGTH, message = MAJOR_LENGTH_MESSAGE)
 		String major,
+
+		@Size(max = MAX_CAREER_LENGTH, message = CAREER_LENGTH_MESSAGE)
 		String career,
+
+		@Size(max = MAX_PROFILE_IMAGE_URL_LENGTH, message = PROFILE_IMAGE_URL_LENGTH_MESSAGE)
 		String profileImageUrl
 ) {
 }

--- a/src/main/java/com/monari/monariback/teacher/entity/Teacher.java
+++ b/src/main/java/com/monari/monariback/teacher/entity/Teacher.java
@@ -70,6 +70,19 @@ public class Teacher extends BaseEntity {
 		return teacher;
 	}
 
+	public Teacher updateProfile(
+			String university,
+			String major,
+			String career,
+			String profileImageUrl
+	) {
+		this.university = university;
+		this.major = major;
+		this.career = career;
+		this.profileImageUrl = profileImageUrl;
+		return this;
+	}
+
 	@PrePersist
 	private void generateUuid() {
 		if (this.publicId == null) {

--- a/src/main/java/com/monari/monariback/teacher/entity/Teacher.java
+++ b/src/main/java/com/monari/monariback/teacher/entity/Teacher.java
@@ -53,7 +53,7 @@ public class Teacher extends BaseEntity {
 	@Column(length = 1000)
 	private String career;
 
-	@Column(length = 255)
+	@Column(length = 500)
 	private String profileImageUrl;
 
 	public static Teacher signUpWithOauth(

--- a/src/main/java/com/monari/monariback/teacher/service/TeacherService.java
+++ b/src/main/java/com/monari/monariback/teacher/service/TeacherService.java
@@ -8,6 +8,8 @@ import org.springframework.transaction.annotation.Transactional;
 import com.monari.monariback.auth.entity.Accessor;
 import com.monari.monariback.global.config.error.exception.NotFoundException;
 import com.monari.monariback.teacher.dto.TeacherDto;
+import com.monari.monariback.teacher.dto.request.TeacherUpdateRequest;
+import com.monari.monariback.teacher.entity.Teacher;
 import com.monari.monariback.teacher.repository.TeacherRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -23,6 +25,20 @@ public class TeacherService {
 		return TeacherDto.from(
 				teacherRepository.findByPublicId(accessor.getPublicId())
 						.orElseThrow(() -> new NotFoundException(TEACHER_NOT_FOUND))
+		);
+	}
+
+	@Transactional
+	public TeacherDto updateProfile(Accessor accessor, TeacherUpdateRequest request) {
+		Teacher teacher = teacherRepository.findByPublicId(accessor.getPublicId())
+				.orElseThrow(() -> new NotFoundException(TEACHER_NOT_FOUND));
+		return TeacherDto.from(
+				teacher.updateProfile(
+						request.university(),
+						request.major(),
+						request.career(),
+						request.profileImageUrl()
+				)
 		);
 	}
 }


### PR DESCRIPTION
## 관련 이슈

> #37 
## 작업 내용
- 학생 정보 수정 기능 구현
  - `StudentService`에 `updateProfile()` 도메인 메서드 구현
  - `StudentController`에 `PATCH /students/me` API 추가
  - `StudentUpdateRequest`에 Validation 추가
  - `StudentValidationConstants`를 통한 제약 조건 상수화

- 선생님 정보 수정 기능 구현
  - `TeacherService`에 `updateProfile()` 메서드 구현
  - `TeacherController`에 `PATCH /teachers/me` API 추가
  - `TeacherUpdateRequest`에 Validation 추가
  - `TeacherValidationConstants` 정의 및 적용

- 공통 예외 처리 개선
  - `GlobalExceptionHandler`에서 Jackson의 Enum 파싱 실패 예외 대응 추가
  - `InvalidFormatException`에 대한 사용자 친화적인 메시지 응답 처리