### PR TITLE
[스터디] 페이징 기반 조회 및 키워드 검색 API 개발

### DIFF
--- a/src/main/java/com/monari/monariback/study/controller/StudyController.java
+++ b/src/main/java/com/monari/monariback/study/controller/StudyController.java
@@ -6,15 +6,15 @@ import com.monari.monariback.auth.entity.Accessor;
 import com.monari.monariback.study.dto.request.StudyChangeStatusRequest;
 import com.monari.monariback.study.dto.request.StudyCreateRequest;
 import com.monari.monariback.study.dto.request.StudyEditRequest;
+import com.monari.monariback.study.dto.response.StudyDetailResponse;
 import com.monari.monariback.study.dto.response.StudyResponse;
 import com.monari.monariback.study.service.StudyService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -31,15 +31,43 @@ public class StudyController {
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
-    @GetMapping()
-    public ResponseEntity<List<StudyResponse>> readStudies() {
-        List<StudyResponse> responses = studyService.readStudies();
-        return new ResponseEntity<>(responses, HttpStatus.OK);
+    /**
+     * 페이지별 스터디 목록 조회
+     * @param pageNum - 페이지 번호
+     * @param pageSize - 한 페이지에 조회될 스터디 개수
+     * @author Jeong
+     */
+    @GetMapping
+    public ResponseEntity<Page<StudyResponse>> getStudies(
+            @RequestParam(name = "pageNum", defaultValue = "1") final int pageNum,
+            @RequestParam(name = "pageSize", defaultValue = "6") final int pageSize
+    ) {
+        Page<StudyResponse> response = studyService.getStudies(pageNum, pageSize);
+        return new ResponseEntity<>(response, HttpStatus.OK);
+    }
+
+    /**
+     * 스터디 검색 기반 페이지별 목록 조회
+     * @param pageNum - 페이지 번호
+     * @param pageSize - 한 페이지에 조회될 스터디 개수
+     * @param titleKeyword - 제목 키워드
+     * @param descriptionKeyword - 설명 키워드
+     * @author Jeong
+     */
+    @GetMapping("/search")
+    public ResponseEntity<Page<StudyResponse>> searchStudies(
+            @RequestParam(name = "pageNum", defaultValue = "1") final int pageNum,
+            @RequestParam(name = "pageSize", defaultValue = "6") final int pageSize,
+            @RequestParam(name = "titleKeyword", required = false) String titleKeyword,
+            @RequestParam(name = "descriptionKeyword", required = false) String descriptionKeyword
+    ) {
+        Page<StudyResponse> response = studyService.searchStudies(pageNum, pageSize, titleKeyword, descriptionKeyword);
+        return new ResponseEntity<>(response, HttpStatus.OK);
     }
 
     @GetMapping("/{studyId}")
-    public ResponseEntity<StudyResponse> readStudy(@PathVariable("studyId") Integer studyId) {
-        StudyResponse response = studyService.readStudy(studyId);
+    public ResponseEntity<StudyDetailResponse> getStudy(@PathVariable("studyId") final Integer studyId) {
+        StudyDetailResponse response = studyService.getStudy(studyId);
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 

--- a/src/main/java/com/monari/monariback/study/dto/StudyDto.java
+++ b/src/main/java/com/monari/monariback/study/dto/StudyDto.java
@@ -1,0 +1,23 @@
+package com.monari.monariback.study.dto;
+
+import com.monari.monariback.common.enumerated.SchoolLevel;
+import com.monari.monariback.common.enumerated.Subject;
+import com.monari.monariback.study.enumerated.StudyStatus;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record StudyDto(
+        Integer id,
+        String title,
+        String description,
+        Subject subject,
+        SchoolLevel schoolLevel,
+        StudyStatus status,
+        LocalDateTime createdAt,
+        String locationName,
+        String locationServiceUrl,
+        UUID studentPublicId,
+        String studentName
+) {
+}

--- a/src/main/java/com/monari/monariback/study/dto/response/StudyDetailResponse.java
+++ b/src/main/java/com/monari/monariback/study/dto/response/StudyDetailResponse.java
@@ -1,0 +1,40 @@
+package com.monari.monariback.study.dto.response;
+
+import com.monari.monariback.common.enumerated.SchoolLevel;
+import com.monari.monariback.common.enumerated.Subject;
+import com.monari.monariback.study.entity.Study;
+import com.monari.monariback.study.enumerated.StudyStatus;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record StudyDetailResponse(
+        Integer id,
+        String title,
+        String description,
+        Subject subject,
+        SchoolLevel schoolLevel,
+        StudyStatus status,
+        LocalDateTime createdAt,
+        String locationName,
+        String locationServiceUrl,
+        UUID studentPublicId,
+        String studentName
+) {
+
+    public static StudyDetailResponse from(Study study) {
+        return new StudyDetailResponse(
+                study.getId(),
+                study.getTitle(),
+                study.getDescription(),
+                study.getSubject(),
+                study.getSchoolLevel(),
+                study.getStatus(),
+                study.getCreatedAt(),
+                study.getLocation().getLocationName(),
+                study.getLocation().getServiceUrl(),
+                study.getStudent().getPublicId(),
+                study.getStudent().getName()
+        );
+    }
+}

--- a/src/main/java/com/monari/monariback/study/dto/response/StudyResponse.java
+++ b/src/main/java/com/monari/monariback/study/dto/response/StudyResponse.java
@@ -1,28 +1,40 @@
 package com.monari.monariback.study.dto.response;
 
-import com.monari.monariback.study.entity.Study;
+import com.monari.monariback.common.enumerated.SchoolLevel;
+import com.monari.monariback.common.enumerated.Subject;
+import com.monari.monariback.study.dto.StudyDto;
+import com.monari.monariback.study.enumerated.StudyStatus;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
 
 public record StudyResponse(
         Integer id,
         String title,
         String description,
-        String subject,
-        String schoolLevel,
-        String status,
+        Subject subject,
+        SchoolLevel schoolLevel,
+        StudyStatus status,
+        LocalDateTime createdAt,
         String locationName,
-        String locationServiceUrl
+        String locationServiceUrl,
+        UUID studentPublicId,
+        String studentName
 ) {
 
-    public static StudyResponse from(Study study) {
+    public static StudyResponse from(StudyDto studyDto) {
         return new StudyResponse(
-                study.getId(),
-                study.getTitle(),
-                study.getDescription(),
-                study.getSubject().name(),
-                study.getSchoolLevel().name(),
-                study.getStatus().name(),
-                study.getLocation().getLocationName(),
-                study.getLocation().getServiceUrl()
+                studyDto.id(),
+                studyDto.title(),
+                studyDto.description(),
+                studyDto.subject(),
+                studyDto.schoolLevel(),
+                studyDto.status(),
+                studyDto.createdAt(),
+                studyDto.locationName(),
+                studyDto.locationServiceUrl(),
+                studyDto.studentPublicId(),
+                studyDto.studentName()
         );
     }
 }

--- a/src/main/java/com/monari/monariback/study/repository/StudyCustomRepository.java
+++ b/src/main/java/com/monari/monariback/study/repository/StudyCustomRepository.java
@@ -1,0 +1,16 @@
+package com.monari.monariback.study.repository;
+
+import com.monari.monariback.study.dto.StudyDto;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface StudyCustomRepository {
+
+    List<StudyDto> findOrderByCreatedAtDesc(Integer pageNum, Integer pageSize);
+
+    List<StudyDto> findByKeywordOrderByCreatedAtDesc(Integer pageNum, Integer pageSize, String titleKeyword, String descriptionKeyword);
+
+    long countByKeyword(String titleKeyword, String descriptionKeyword);
+}

--- a/src/main/java/com/monari/monariback/study/repository/StudyRepository.java
+++ b/src/main/java/com/monari/monariback/study/repository/StudyRepository.java
@@ -6,18 +6,10 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
 import java.util.Optional;
 
 @Repository
-public interface StudyRepository extends JpaRepository<Study, Integer> {
-
-    @Query("""
-        SELECT s
-        FROM Study s
-        JOIN FETCH s.location
-    """)
-    List<Study> findAllWithLocation();
+public interface StudyRepository extends JpaRepository<Study, Integer>, StudyCustomRepository {
 
     @Query("""
         SELECT s
@@ -26,4 +18,13 @@ public interface StudyRepository extends JpaRepository<Study, Integer> {
         WHERE s.id = :id
     """)
     Optional<Study> findByIdWithStudent(@Param("id") Integer id) ;
+
+    @Query("""
+        SELECT s
+        FROM Study s
+        JOIN FETCH s.student
+        JOIN FETCH s.location
+        WHERE s.id = :id
+    """)
+    Optional<Study> findByIdWithStudentAndLocation(@Param("id") Integer id) ;
 }

--- a/src/main/java/com/monari/monariback/study/repository/impl/StudyCustomRepositoryImpl.java
+++ b/src/main/java/com/monari/monariback/study/repository/impl/StudyCustomRepositoryImpl.java
@@ -1,0 +1,100 @@
+package com.monari.monariback.study.repository.impl;
+
+import com.monari.monariback.study.dto.StudyDto;
+import com.monari.monariback.study.repository.StudyCustomRepository;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import io.micrometer.common.util.StringUtils;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static com.monari.monariback.location.entity.QLocation.location;
+import static com.monari.monariback.student.entity.QStudent.student;
+import static com.monari.monariback.study.entity.QStudy.study;
+
+@Repository
+@RequiredArgsConstructor
+public class StudyCustomRepositoryImpl implements StudyCustomRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<StudyDto> findOrderByCreatedAtDesc(Integer pageNum, Integer pageSize) {
+        return queryFactory
+                .select(Projections.constructor(StudyDto.class,
+                        study.id,
+                        study.title,
+                        study.description,
+                        study.subject,
+                        study.schoolLevel,
+                        study.status,
+                        study.createdAt,
+                        study.location.locationName,
+                        study.location.serviceUrl,
+                        study.student.publicId,
+                        study.student.name
+                        ))
+                .from(study)
+                .innerJoin(study.location, location)
+                .innerJoin(study.student, student)
+                .orderBy(study.createdAt.desc(), study.id.desc())
+                .limit(pageSize)
+                .offset((long) pageSize * (pageNum - 1))
+                .fetch();
+    }
+
+    @Override
+    public List<StudyDto> findByKeywordOrderByCreatedAtDesc(Integer pageNum, Integer pageSize, String titleKeyword, String descriptionKeyword) {
+        return queryFactory
+                .select(Projections.constructor(StudyDto.class,
+                        study.id,
+                        study.title,
+                        study.description,
+                        study.subject,
+                        study.schoolLevel,
+                        study.status,
+                        study.createdAt,
+                        study.location.locationName,
+                        study.location.serviceUrl,
+                        study.student.publicId,
+                        study.student.name
+                        ))
+                .from(study)
+                .innerJoin(study.location, location)
+                .innerJoin(study.student, student)
+                .where(containsTitleKeyword(titleKeyword))
+                .where(containsDescriptionKeyword(descriptionKeyword))
+                .orderBy(study.createdAt.desc(), study.id.desc())
+                .limit(pageSize)
+                .offset((long) pageSize * (pageNum - 1))
+                .fetch();
+    }
+
+    @Override
+    public long countByKeyword(String titleKeyword, String descriptionKeyword) {
+        Long count = queryFactory.select(study.count())
+                .from(study)
+                .where(containsTitleKeyword(titleKeyword))
+                .where(containsDescriptionKeyword(descriptionKeyword))
+                .fetchOne();
+
+        return count != null ? count : 0L;
+    }
+
+    private BooleanExpression containsTitleKeyword(String keyword) {
+        if (StringUtils.isEmpty(keyword)) {
+            return null;
+        }
+        return study.title.containsIgnoreCase(keyword);
+    }
+
+    private BooleanExpression containsDescriptionKeyword(String keyword) {
+        if (StringUtils.isEmpty(keyword)) {
+            return null;
+        }
+        return study.description.containsIgnoreCase(keyword);
+    }
+}


### PR DESCRIPTION
## 관련 이슈

> #21 

## 작업 내용
- 페이지별 스터디 목록 조회 API 개발
- 스터디 검색 기반 페이지별 목록 조회 API 개발
  - 제목 키워드, 설명 키워드를 이용한 검색 기능
- 컨트롤러 메서드명 변경
  - 조회 메서드명 read -> get

## ETC
- PageImpl 생성 시 파라미터 pageNumber는 zero-based이기 때문에 pageNum - 1으로 인수를 넘겨줘야 해서 API 응답 결과pageNumber가 1씩 작음 (0부터 시작)
![pageNumber](https://github.com/user-attachments/assets/50a4d126-f407-475d-920e-9758111f14d2)

리팩토링은 차차 하겠습니다!
