### PR TITLE
[선생님] 은행/계좌 관련 필드 추가 및 프로필 수정 API 업데이트

### DIFF
--- a/src/main/java/com/monari/monariback/teacher/constant/TeacherValidationConstants.java
+++ b/src/main/java/com/monari/monariback/teacher/constant/TeacherValidationConstants.java
@@ -9,9 +9,15 @@ public class TeacherValidationConstants {
 	public static final int MAX_MAJOR_LENGTH = 100;
 	public static final int MAX_CAREER_LENGTH = 1000;
 	public static final int MAX_PROFILE_IMAGE_URL_LENGTH = 500;
+	public static final int MAX_BANK_NAME_LENGTH = 100;
+	public static final int MAX_ACCOUNT_NUMBER_LENGTH = 50;
+	public static final int MAX_ACCOUNT_HOLDER_LENGTH = 50;
 
 	public static final String UNIVERSITY_LENGTH_MESSAGE = "대학교명은 100자 이하여야 합니다.";
 	public static final String MAJOR_LENGTH_MESSAGE = "전공명은 100자 이하여야 합니다.";
 	public static final String CAREER_LENGTH_MESSAGE = "경력 내용은 1000자 이하여야 합니다.";
 	public static final String PROFILE_IMAGE_URL_LENGTH_MESSAGE = "프로필 이미지 URL은 500자 이하여야 합니다.";
+	public static final String BANK_NAME_LENGTH_MESSAGE = "은행명은 최대 " + MAX_BANK_NAME_LENGTH + "자까지 입력 가능합니다.";
+	public static final String ACCOUNT_NUMBER_LENGTH_MESSAGE = "계좌번호는 최대 " + MAX_ACCOUNT_NUMBER_LENGTH + "자까지 입력 가능합니다.";
+	public static final String ACCOUNT_HOLDER_LENGTH_MESSAGE = "예금주명은 최대 " + MAX_ACCOUNT_HOLDER_LENGTH + "자까지 입력 가능합니다.";
 }

--- a/src/main/java/com/monari/monariback/teacher/dto/TeacherDto.java
+++ b/src/main/java/com/monari/monariback/teacher/dto/TeacherDto.java
@@ -11,7 +11,10 @@ public record TeacherDto(
 		String university,
 		String major,
 		String career,
-		String profileImageUrl
+		String profileImageUrl,
+		String bankName,
+		String accountNumber,
+		String accountHolder
 ) {
 	public static TeacherDto from(Teacher teacher) {
 		return new TeacherDto(
@@ -21,7 +24,10 @@ public record TeacherDto(
 				teacher.getUniversity(),
 				teacher.getMajor(),
 				teacher.getCareer(),
-				teacher.getProfileImageUrl()
+				teacher.getProfileImageUrl(),
+				teacher.getBankName(),
+				teacher.getAccountNumber(),
+				teacher.getAccountHolder()
 		);
 	}
 }

--- a/src/main/java/com/monari/monariback/teacher/dto/request/TeacherUpdateRequest.java
+++ b/src/main/java/com/monari/monariback/teacher/dto/request/TeacherUpdateRequest.java
@@ -15,6 +15,15 @@ public record TeacherUpdateRequest(
 		String career,
 
 		@Size(max = MAX_PROFILE_IMAGE_URL_LENGTH, message = PROFILE_IMAGE_URL_LENGTH_MESSAGE)
-		String profileImageUrl
+		String profileImageUrl,
+
+		@Size(max = MAX_BANK_NAME_LENGTH, message = BANK_NAME_LENGTH_MESSAGE)
+		String bankName,
+
+		@Size(max = MAX_ACCOUNT_NUMBER_LENGTH, message = ACCOUNT_NUMBER_LENGTH_MESSAGE)
+		String accountNumber,
+
+		@Size(max = MAX_ACCOUNT_HOLDER_LENGTH, message = ACCOUNT_HOLDER_LENGTH_MESSAGE)
+		String accountHolder
 ) {
 }

--- a/src/main/java/com/monari/monariback/teacher/dto/response/TeacherResponse.java
+++ b/src/main/java/com/monari/monariback/teacher/dto/response/TeacherResponse.java
@@ -11,7 +11,10 @@ public record TeacherResponse(
 		String university,
 		String major,
 		String career,
-		String profileImageUrl
+		String profileImageUrl,
+		String bankName,
+		String accountNumber,
+		String accountHolder
 ) {
 	public static TeacherResponse from(TeacherDto teacherDto) {
 		return new TeacherResponse(
@@ -21,7 +24,10 @@ public record TeacherResponse(
 				teacherDto.university(),
 				teacherDto.major(),
 				teacherDto.career(),
-				teacherDto.profileImageUrl()
+				teacherDto.profileImageUrl(),
+				teacherDto.bankName(),
+				teacherDto.accountNumber(),
+				teacherDto.accountHolder()
 		);
 	}
 }

--- a/src/main/java/com/monari/monariback/teacher/entity/Teacher.java
+++ b/src/main/java/com/monari/monariback/teacher/entity/Teacher.java
@@ -83,12 +83,18 @@ public class Teacher extends BaseEntity {
 			String university,
 			String major,
 			String career,
-			String profileImageUrl
+			String profileImageUrl,
+			String bankName,
+			String accountNumber,
+			String accountHolder
 	) {
 		this.university = university;
 		this.major = major;
 		this.career = career;
 		this.profileImageUrl = profileImageUrl;
+		this.bankName = bankName;
+		this.accountNumber = accountNumber;
+		this.accountHolder = accountHolder;
 		return this;
 	}
 

--- a/src/main/java/com/monari/monariback/teacher/entity/Teacher.java
+++ b/src/main/java/com/monari/monariback/teacher/entity/Teacher.java
@@ -56,6 +56,15 @@ public class Teacher extends BaseEntity {
 	@Column(length = 500)
 	private String profileImageUrl;
 
+	@Column(length = 100)
+	private String bankName;
+
+	@Column(length = 50)
+	private String accountNumber;
+
+	@Column(length = 50)
+	private String accountHolder;
+
 	public static Teacher signUpWithOauth(
 			String email,
 			String name,

--- a/src/main/java/com/monari/monariback/teacher/service/TeacherService.java
+++ b/src/main/java/com/monari/monariback/teacher/service/TeacherService.java
@@ -37,7 +37,10 @@ public class TeacherService {
 						request.university(),
 						request.major(),
 						request.career(),
-						request.profileImageUrl()
+						request.profileImageUrl(),
+						request.bankName(),
+						request.accountNumber(),
+						request.accountHolder()
 				)
 		);
 	}

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -69,28 +69,51 @@ VALUES (RANDOM_UUID(), 'student1@example.com', '김민지', 'KAKAO', 'kakao123',
         CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
 
 -- Teacher (선생님) 데이터 (10건)
-INSERT INTO teacher (public_id, email, name, social_provider, social_id, university, major, career,
-                     created_at, updated_at)
-VALUES (RANDOM_UUID(), 'teacher1@example.com', '김철수 교수', 'KAKAO', 't_kakao1', '한국대학교', '수학과',
-        '10년 강의 경력, 미적분학 전문', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
-       (RANDOM_UUID(), 'teacher2@example.com', '이영희 박사', 'NAVER', 't_naver2', '서울대학교', '물리학과',
-        '5년 연구 및 3년 강의, 양자역학', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
-       (RANDOM_UUID(), 'teacher3@example.com', '박민준 선생님', 'NAVER', 't_naver3', '연세대학교', '화학과',
-        '고등학교 화학 교사 7년', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
-       (RANDOM_UUID(), 'teacher4@example.com', '최지우 교사', 'KAKAO', 't_kakao4', '고려대학교', '생명과학과',
-        '중학교 과학 교사 5년', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
-       (RANDOM_UUID(), 'teacher5@example.com', '정다빈 연구원', 'NAVER', 't_naver5', 'KAIST', '수학과',
-        '응용수학 연구 8년', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
-       (RANDOM_UUID(), 'teacher6@example.com', '강태현 선생님', 'NAVER', 't_naver6', '성균관대학교', '물리학과',
-        '물리 올림피아드 지도 경험 다수', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
-       (RANDOM_UUID(), 'teacher7@example.com', '윤서아 박사', 'KAKAO', 't_kakao7', '포항공과대학교', '화학과',
-        '유기화학 연구 및 특강 전문', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
-       (RANDOM_UUID(), 'teacher8@example.com', '한지민 교사', 'NAVER', 't_naver8', '한양대학교', '생명과학과',
-        '과학 탐구반 지도 6년', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
-       (RANDOM_UUID(), 'teacher9@example.com', '배준호 교수', 'NAVER', 't_naver9', '경희대학교', '수학과',
-        '확률 및 통계 강의 12년', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
-       (RANDOM_UUID(), 'teacher10@example.com', '송지효 연구원', 'KAKAO', 't_kakao10', '중앙대학교', '물리학과',
-        '천체물리학 연구 4년', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+INSERT INTO teacher (
+    public_id,
+    email,
+    name,
+    social_provider,
+    social_id,
+    university,
+    major,
+    career,
+    created_at,
+    updated_at,
+    bank_name,
+    account_number,
+    account_holder
+)
+VALUES
+    (RANDOM_UUID(), 'teacher1@example.com', '김철수 교수', 'KAKAO', 't_kakao1', '한국대학교', '수학과',
+     '10년 강의 경력, 미적분학 전문', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, '국민은행', '1111111111', '김철수 교수'),
+
+    (RANDOM_UUID(), 'teacher2@example.com', '이영희 박사', 'NAVER', 't_naver2', '서울대학교', '물리학과',
+     '5년 연구 및 3년 강의, 양자역학', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, '신한은행', '2222222222', '이영희 박사'),
+
+    (RANDOM_UUID(), 'teacher3@example.com', '박민준 선생님', 'NAVER', 't_naver3', '연세대학교', '화학과',
+     '고등학교 화학 교사 7년', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, '하나은행', '3333333333', '박민준 선생님'),
+
+    (RANDOM_UUID(), 'teacher4@example.com', '최지우 교사', 'KAKAO', 't_kakao4', '고려대학교', '생명과학과',
+     '중학교 과학 교사 5년', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, '우리은행', '4444444444', '최지우 교사'),
+
+    (RANDOM_UUID(), 'teacher5@example.com', '정다빈 연구원', 'NAVER', 't_naver5', 'KAIST', '수학과',
+     '응용수학 연구 8년', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, '농협은행', '5555555555', '정다빈 연구원'),
+
+    (RANDOM_UUID(), 'teacher6@example.com', '강태현 선생님', 'NAVER', 't_naver6', '성균관대학교', '물리학과',
+     '물리 올림피아드 지도 경험 다수', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, '국민은행', '6666666666', '강태현 선생님'),
+
+    (RANDOM_UUID(), 'teacher7@example.com', '윤서아 박사', 'KAKAO', 't_kakao7', '포항공과대학교', '화학과',
+     '유기화학 연구 및 특강 전문', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, '신한은행', '7777777777', '윤서아 박사'),
+
+    (RANDOM_UUID(), 'teacher8@example.com', '한지민 교사', 'NAVER', 't_naver8', '한양대학교', '생명과학과',
+     '과학 탐구반 지도 6년', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, '하나은행', '8888888888', '한지민 교사'),
+
+    (RANDOM_UUID(), 'teacher9@example.com', '배준호 교수', 'NAVER', 't_naver9', '경희대학교', '수학과',
+     '확률 및 통계 강의 12년', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, '우리은행', '9999999999', '배준호 교수'),
+
+    (RANDOM_UUID(), 'teacher10@example.com', '송지효 연구원', 'KAKAO', 't_kakao10', '중앙대학교', '물리학과',
+     '천체물리학 연구 4년', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, '농협은행', '1010101010', '송지효 연구원');
 
 -- Lesson (수업) 데이터 (10건) - location_id 고유하게 수정됨
 -- Location ID 1-10 및 Teacher ID 1-10 사용 가정


### PR DESCRIPTION
## 관련 이슈

> #51 

## 작업 내용
- **Teacher 엔티티 수정**
  - Teacher 테이블에 은행/계좌 관련 새로운 필드 추가  
    - `bankName` (은행명)  
    - `accountNumber` (계좌번호)  
    - `accountHolder` (예금주명)
    
- **Teacher DTO 수정**  
  - TeacherUpdateRequest에 은행/계좌 관련 필드 추가 및 유효성 검증 로직 반영

- **프로필 수정 API 업데이트**  
  - 선생님의 프로필 정보를 수정할 때, 은행/계좌 관련 정보도 함께 수정 가능하도록 API 업데이트

- **Teacher Mock data 수정**
