### PR TITLE
[선생님] PublicId 기반 조회 API 구현

### DIFF
--- a/src/main/java/com/monari/monariback/teacher/controller/TeacherController.java
+++ b/src/main/java/com/monari/monariback/teacher/controller/TeacherController.java
@@ -1,8 +1,11 @@
 package com.monari.monariback.teacher.controller;
 
+import java.util.UUID;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -23,6 +26,15 @@ import lombok.RequiredArgsConstructor;
 public class TeacherController {
 
 	private final TeacherService teacherService;
+
+	@GetMapping("/{publicId}")
+	public ResponseEntity<TeacherResponse> getTeacher(@PathVariable UUID publicId) {
+		return ResponseEntity.ok().body(
+				TeacherResponse.from(
+						teacherService.getTeacher(publicId)
+				)
+		);
+	}
 
 	@OnlyTeacher
 	@GetMapping("/me")

--- a/src/main/java/com/monari/monariback/teacher/service/TeacherService.java
+++ b/src/main/java/com/monari/monariback/teacher/service/TeacherService.java
@@ -1,5 +1,9 @@
 package com.monari.monariback.teacher.service;
 
+import static com.monari.monariback.common.error.ErrorCode.*;
+
+import java.util.UUID;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -11,8 +15,6 @@ import com.monari.monariback.teacher.entity.Teacher;
 import com.monari.monariback.teacher.repository.TeacherRepository;
 
 import lombok.RequiredArgsConstructor;
-
-import static com.monari.monariback.common.error.ErrorCode.TEACHER_NOT_FOUND;
 
 @Service
 @RequiredArgsConstructor
@@ -42,6 +44,14 @@ public class TeacherService {
 						request.accountNumber(),
 						request.accountHolder()
 				)
+		);
+	}
+
+	@Transactional(readOnly = true)
+	public TeacherDto getTeacher(UUID publicId) {
+		return TeacherDto.from(
+				teacherRepository.findByPublicId(publicId)
+						.orElseThrow(() -> new NotFoundException(TEACHER_NOT_FOUND))
 		);
 	}
 }

--- a/src/main/java/com/monari/monariback/teacher/service/TeacherService.java
+++ b/src/main/java/com/monari/monariback/teacher/service/TeacherService.java
@@ -25,8 +25,7 @@ public class TeacherService {
 	@Transactional(readOnly = true)
 	public TeacherDto findMyProfile(Accessor accessor) {
 		return TeacherDto.from(
-				teacherRepository.findByPublicId(accessor.getPublicId())
-						.orElseThrow(() -> new NotFoundException(TEACHER_NOT_FOUND))
+				getTeacherByPublicId(accessor.getPublicId())
 		);
 	}
 
@@ -49,9 +48,11 @@ public class TeacherService {
 
 	@Transactional(readOnly = true)
 	public TeacherDto getTeacher(UUID publicId) {
-		return TeacherDto.from(
-				teacherRepository.findByPublicId(publicId)
-						.orElseThrow(() -> new NotFoundException(TEACHER_NOT_FOUND))
-		);
+		return TeacherDto.from(getTeacherByPublicId(publicId));
+	}
+
+	private Teacher getTeacherByPublicId(UUID publicId) {
+		return teacherRepository.findByPublicId(publicId)
+				.orElseThrow(() -> new NotFoundException(TEACHER_NOT_FOUND));
 	}
 }

--- a/src/main/java/com/monari/monariback/teacher/service/TeacherService.java
+++ b/src/main/java/com/monari/monariback/teacher/service/TeacherService.java
@@ -24,9 +24,7 @@ public class TeacherService {
 
 	@Transactional(readOnly = true)
 	public TeacherDto findMyProfile(Accessor accessor) {
-		return TeacherDto.from(
-				getTeacherByPublicId(accessor.getPublicId())
-		);
+		return getTeacher(accessor.getPublicId());
 	}
 
 	@Transactional
@@ -48,11 +46,9 @@ public class TeacherService {
 
 	@Transactional(readOnly = true)
 	public TeacherDto getTeacher(UUID publicId) {
-		return TeacherDto.from(getTeacherByPublicId(publicId));
-	}
-
-	private Teacher getTeacherByPublicId(UUID publicId) {
-		return teacherRepository.findByPublicId(publicId)
-				.orElseThrow(() -> new NotFoundException(TEACHER_NOT_FOUND));
+		return TeacherDto.from(
+				teacherRepository.findByPublicId(publicId)
+						.orElseThrow(() -> new NotFoundException(TEACHER_NOT_FOUND))
+		);
 	}
 }


### PR DESCRIPTION
## 관련 이슈

> #56 

## 작업 내용
- TeacherController에 GET /api/v1/teachers/{publicId} 기반 조회 API 구현
  - PathVariable로 전달받은 publicId (UUID 형식)를 기반으로 선생님 정보를 조회합니다.
  - teacherService를 호출하여 선생님 정보를 가져오고, 이를 TeacherResponse DTO로 변환하여 반환합니다.

## ETC
> **주의사항:**
> - 이 API는 DB에 저장된 선생님의 public_id를 기반으로 정보를 조회합니다.
> - 경로 변수(publicId)로 사용할 값은 반드시 API 호출을 통해 받아온 올바른 UUID 값을 사용해 주세요.
> - API 응답으로 제공되는 publicId 값을 그대로 사용하면, 형식 오류 없이 안정적으로 조회할 수 있습니다.
>   - 예를 들어, 다른 API 응답이나 DB 조회 결과로 받은 publicId 값인 "477e9942-b0f1-4366-b58a-0d1079746c4b"를 그대로 사용해야 합니다.
>   - 하이픈 없는 "477e9942b0f14366b58a0d1079746c4b"와 같이 잘못된 형식의 값을 사용하면 형식 오류가 발생하여 API가 400 Bad Request를 반환합니다.

```
	@Transactional(readOnly = true)
	public TeacherDto findMyProfile(Accessor accessor) {
		return getTeacher(accessor.getPublicId());
	}
	
	@Transactional(readOnly = true)
	public TeacherDto getTeacher(UUID publicId) {
		return TeacherDto.from(
				teacherRepository.findByPublicId(publicId)
						.orElseThrow(() -> new NotFoundException(TEACHER_NOT_FOUND))
		);
	}
```

두 메서드 모두 `@Transactional(readOnly = true)` 어노테이션을 선언해도 별도의 성능 낭비가 발생하지 않습니다.
### AOP 프록시 및 내부 호출
같은 빈(클래스) 내에서 findMyProfile이 getTeacher를 호출하는 경우, 실제로는 AOP 프록시를 통한 별도의 트랜잭션 경계가 새로 형성되지 않습니다. 외부에서 호출한 findMyProfile 메서드의 트랜잭션 컨텍스트를 그대로 재사용하게 됩니다.