### PR TITLE
[스터디] 검색 시 대상, 과목, 지역구도 포함하기

### DIFF
--- a/src/main/java/com/monari/monariback/study/constant/StudyValidationConstants.java
+++ b/src/main/java/com/monari/monariback/study/constant/StudyValidationConstants.java
@@ -1,0 +1,12 @@
+package com.monari.monariback.study.constant;
+
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class StudyValidationConstants {
+    public static final int MAX_TITLE_LENGTH = 100;
+    public static final int MAX_DESCRIPTION_LENGTH = 5000;
+
+   	public static final String MAX_TITLE_LENGTH_MESSAGE = "스터디 제목은 100자 이하여야 합니다.";
+   	public static final String MAX_DESCRIPTION_LENGTH_MESSAGE = "스터디 설명은 5000자 이하여야 합니다.";
+}

--- a/src/main/java/com/monari/monariback/study/controller/StudyController.java
+++ b/src/main/java/com/monari/monariback/study/controller/StudyController.java
@@ -6,6 +6,7 @@ import com.monari.monariback.auth.entity.Accessor;
 import com.monari.monariback.study.dto.request.StudyChangeStatusRequest;
 import com.monari.monariback.study.dto.request.StudyCreateRequest;
 import com.monari.monariback.study.dto.request.StudyEditRequest;
+import com.monari.monariback.study.dto.request.StudySearchRequest;
 import com.monari.monariback.study.dto.response.StudyDetailResponse;
 import com.monari.monariback.study.dto.response.StudyResponse;
 import com.monari.monariback.study.service.StudyService;
@@ -48,20 +49,23 @@ public class StudyController {
 
     /**
      * 스터디 검색 기반 페이지별 목록 조회
-     * @param pageNum - 페이지 번호
-     * @param pageSize - 한 페이지에 조회될 스터디 개수
-     * @param titleKeyword - 제목 키워드
-     * @param descriptionKeyword - 설명 키워드
+     * 최신순 정렬
+     * @param int pageNum - 페이지 번호
+     * @param int pageSize - 한 페이지에 조회될 스터디 개수
+     * @param String titleKeyword - 제목 키워드
+     * @param String descriptionKeyword - 설명 키워드
+     * @param SchoolLevel schoolLevel, - 학교급
+     * @param Subject subject, - 과목
+     * @param Region region - 지역구
      * @author Jeong
      */
     @GetMapping("/search")
     public ResponseEntity<Page<StudyResponse>> searchStudies(
             @RequestParam(name = "pageNum", defaultValue = "1") final int pageNum,
             @RequestParam(name = "pageSize", defaultValue = "6") final int pageSize,
-            @RequestParam(name = "titleKeyword", required = false) String titleKeyword,
-            @RequestParam(name = "descriptionKeyword", required = false) String descriptionKeyword
+            @Valid final StudySearchRequest request
     ) {
-        Page<StudyResponse> response = studyService.searchStudies(pageNum, pageSize, titleKeyword, descriptionKeyword);
+        Page<StudyResponse> response = studyService.searchStudies(pageNum, pageSize, request);
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 

--- a/src/main/java/com/monari/monariback/study/dto/StudyDto.java
+++ b/src/main/java/com/monari/monariback/study/dto/StudyDto.java
@@ -1,5 +1,6 @@
 package com.monari.monariback.study.dto;
 
+import com.monari.monariback.common.enumerated.Region;
 import com.monari.monariback.common.enumerated.SchoolLevel;
 import com.monari.monariback.common.enumerated.Subject;
 import com.monari.monariback.study.enumerated.StudyStatus;
@@ -13,6 +14,7 @@ public record StudyDto(
         String description,
         Subject subject,
         SchoolLevel schoolLevel,
+        Region region,
         StudyStatus status,
         LocalDateTime createdAt,
         String locationName,

--- a/src/main/java/com/monari/monariback/study/dto/request/StudyCreateRequest.java
+++ b/src/main/java/com/monari/monariback/study/dto/request/StudyCreateRequest.java
@@ -1,5 +1,6 @@
 package com.monari.monariback.study.dto.request;
 
+import com.monari.monariback.common.enumerated.Region;
 import com.monari.monariback.common.enumerated.SchoolLevel;
 import com.monari.monariback.common.enumerated.Subject;
 import jakarta.validation.constraints.NotNull;
@@ -11,6 +12,7 @@ public record StudyCreateRequest (
         @Size(max = 5000) @NotNull String description,
         @NotNull Subject subject,
         @NotNull SchoolLevel schoolLevel,
+        @NotNull Region region,
         @Positive @NotNull Integer locationId
 ) {
 }

--- a/src/main/java/com/monari/monariback/study/dto/request/StudyCreateRequest.java
+++ b/src/main/java/com/monari/monariback/study/dto/request/StudyCreateRequest.java
@@ -7,9 +7,17 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.Size;
 
+import static com.monari.monariback.study.constant.StudyValidationConstants.*;
+
 public record StudyCreateRequest (
-        @Size(max = 100) @NotNull String title,
-        @Size(max = 5000) @NotNull String description,
+        @NotNull
+        @Size(max = MAX_TITLE_LENGTH, message = MAX_TITLE_LENGTH_MESSAGE)
+        String title,
+
+        @NotNull
+        @Size(max = MAX_DESCRIPTION_LENGTH, message = MAX_DESCRIPTION_LENGTH_MESSAGE)
+        String description,
+
         @NotNull Subject subject,
         @NotNull SchoolLevel schoolLevel,
         @NotNull Region region,

--- a/src/main/java/com/monari/monariback/study/dto/request/StudyEditRequest.java
+++ b/src/main/java/com/monari/monariback/study/dto/request/StudyEditRequest.java
@@ -7,9 +7,18 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.Size;
 
+import static com.monari.monariback.study.constant.StudyValidationConstants.*;
+import static com.monari.monariback.study.constant.StudyValidationConstants.MAX_DESCRIPTION_LENGTH_MESSAGE;
+
 public record StudyEditRequest(
-        @Size(max = 100) @NotNull String title,
-        @Size(max = 5000) @NotNull String description,
+        @NotNull
+        @Size(max = MAX_TITLE_LENGTH, message = MAX_TITLE_LENGTH_MESSAGE)
+        String title,
+
+        @NotNull
+        @Size(max = MAX_DESCRIPTION_LENGTH, message = MAX_DESCRIPTION_LENGTH_MESSAGE)
+        String description,
+
         @NotNull Subject subject,
         @NotNull SchoolLevel schoolLevel,
         @NotNull Region region,

--- a/src/main/java/com/monari/monariback/study/dto/request/StudyEditRequest.java
+++ b/src/main/java/com/monari/monariback/study/dto/request/StudyEditRequest.java
@@ -1,5 +1,6 @@
 package com.monari.monariback.study.dto.request;
 
+import com.monari.monariback.common.enumerated.Region;
 import com.monari.monariback.common.enumerated.SchoolLevel;
 import com.monari.monariback.common.enumerated.Subject;
 import jakarta.validation.constraints.NotNull;
@@ -11,6 +12,7 @@ public record StudyEditRequest(
         @Size(max = 5000) @NotNull String description,
         @NotNull Subject subject,
         @NotNull SchoolLevel schoolLevel,
+        @NotNull Region region,
         @Positive @NotNull Integer locationId
 ) {
 }

--- a/src/main/java/com/monari/monariback/study/dto/request/StudySearchRequest.java
+++ b/src/main/java/com/monari/monariback/study/dto/request/StudySearchRequest.java
@@ -6,16 +6,10 @@ import com.monari.monariback.common.enumerated.Subject;
 import jakarta.annotation.Nullable;
 
 public record StudySearchRequest(
-        @Nullable
-        String titleKeyword,
-        @Nullable
-        String descriptionKeyword,
-        @Nullable
-        SchoolLevel schoolLevel,
-        @Nullable
-        Subject subject,
-        @Nullable
-        Region region
+        @Nullable String titleKeyword,
+        @Nullable String descriptionKeyword,
+        @Nullable SchoolLevel schoolLevel,
+        @Nullable Subject subject,
+        @Nullable Region region
 ) {
-
 }

--- a/src/main/java/com/monari/monariback/study/dto/request/StudySearchRequest.java
+++ b/src/main/java/com/monari/monariback/study/dto/request/StudySearchRequest.java
@@ -1,0 +1,21 @@
+package com.monari.monariback.study.dto.request;
+
+import com.monari.monariback.common.enumerated.Region;
+import com.monari.monariback.common.enumerated.SchoolLevel;
+import com.monari.monariback.common.enumerated.Subject;
+import jakarta.annotation.Nullable;
+
+public record StudySearchRequest(
+        @Nullable
+        String titleKeyword,
+        @Nullable
+        String descriptionKeyword,
+        @Nullable
+        SchoolLevel schoolLevel,
+        @Nullable
+        Subject subject,
+        @Nullable
+        Region region
+) {
+
+}

--- a/src/main/java/com/monari/monariback/study/dto/response/StudyDetailResponse.java
+++ b/src/main/java/com/monari/monariback/study/dto/response/StudyDetailResponse.java
@@ -1,5 +1,6 @@
 package com.monari.monariback.study.dto.response;
 
+import com.monari.monariback.common.enumerated.Region;
 import com.monari.monariback.common.enumerated.SchoolLevel;
 import com.monari.monariback.common.enumerated.Subject;
 import com.monari.monariback.study.entity.Study;
@@ -14,6 +15,7 @@ public record StudyDetailResponse(
         String description,
         Subject subject,
         SchoolLevel schoolLevel,
+        Region region,
         StudyStatus status,
         LocalDateTime createdAt,
         String locationName,
@@ -29,6 +31,7 @@ public record StudyDetailResponse(
                 study.getDescription(),
                 study.getSubject(),
                 study.getSchoolLevel(),
+                study.getRegion(),
                 study.getStatus(),
                 study.getCreatedAt(),
                 study.getLocation().getLocationName(),

--- a/src/main/java/com/monari/monariback/study/dto/response/StudyResponse.java
+++ b/src/main/java/com/monari/monariback/study/dto/response/StudyResponse.java
@@ -1,5 +1,6 @@
 package com.monari.monariback.study.dto.response;
 
+import com.monari.monariback.common.enumerated.Region;
 import com.monari.monariback.common.enumerated.SchoolLevel;
 import com.monari.monariback.common.enumerated.Subject;
 import com.monari.monariback.study.dto.StudyDto;
@@ -14,6 +15,7 @@ public record StudyResponse(
         String description,
         Subject subject,
         SchoolLevel schoolLevel,
+        Region region,
         StudyStatus status,
         LocalDateTime createdAt,
         String locationName,
@@ -29,6 +31,7 @@ public record StudyResponse(
                 studyDto.description(),
                 studyDto.subject(),
                 studyDto.schoolLevel(),
+                studyDto.region(),
                 studyDto.status(),
                 studyDto.createdAt(),
                 studyDto.locationName(),

--- a/src/main/java/com/monari/monariback/study/entity/Study.java
+++ b/src/main/java/com/monari/monariback/study/entity/Study.java
@@ -1,6 +1,7 @@
 package com.monari.monariback.study.entity;
 
 import com.monari.monariback.common.entity.BaseEntity;
+import com.monari.monariback.common.enumerated.Region;
 import com.monari.monariback.common.enumerated.SchoolLevel;
 import com.monari.monariback.common.enumerated.Subject;
 import com.monari.monariback.location.entity.Location;
@@ -33,6 +34,9 @@ public class Study extends BaseEntity {
     private SchoolLevel schoolLevel;
 
     @Enumerated(EnumType.STRING)
+    private Region region;
+
+    @Enumerated(EnumType.STRING)
     private StudyStatus status;
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -48,6 +52,7 @@ public class Study extends BaseEntity {
             String description,
             Subject subject,
             SchoolLevel schoolLevel,
+            Region region,
             Location location,
             Student student
     ) {
@@ -57,6 +62,7 @@ public class Study extends BaseEntity {
         study.subject = subject;
         study.schoolLevel = schoolLevel;
         study.status = StudyStatus.ACTIVE;
+        study.region = region;
         study.location = location;
         study.student = student;
         return study;

--- a/src/main/java/com/monari/monariback/study/repository/StudyCustomRepository.java
+++ b/src/main/java/com/monari/monariback/study/repository/StudyCustomRepository.java
@@ -1,5 +1,8 @@
 package com.monari.monariback.study.repository;
 
+import com.monari.monariback.common.enumerated.Region;
+import com.monari.monariback.common.enumerated.SchoolLevel;
+import com.monari.monariback.common.enumerated.Subject;
 import com.monari.monariback.study.dto.StudyDto;
 import org.springframework.stereotype.Repository;
 
@@ -10,11 +13,24 @@ public interface StudyCustomRepository {
 
     List<StudyDto> findOrderByCreatedAtDesc(int pageNum, int pageSize);
 
-    List<StudyDto> findByKeywordOrderByCreatedAtDesc(int pageNum, int pageSize, String titleKeyword, String descriptionKeyword);
+    List<StudyDto> findByKeywordsOrderByCreatedAtDesc(
+            int pageNum,
+            int pageSize,
+            String titleKeyword,
+            String descriptionKeyword,
+            SchoolLevel schoolLevel,
+            Subject subject, Region region
+    );
 
     List<StudyDto> findByStudentIdOrderByCreatedAtDesc(int pageNum, int pageSize, Integer studentId);
 
-    long countByKeyword(String titleKeyword, String descriptionKeyword);
+    long countByKeywords(
+            String titleKeyword,
+            String descriptionKeyword,
+            SchoolLevel schoolLevel,
+            Subject subject,
+            Region region
+    );
 
     long countByStudentId(Integer studentId);
 }

--- a/src/main/java/com/monari/monariback/study/service/StudyService.java
+++ b/src/main/java/com/monari/monariback/study/service/StudyService.java
@@ -11,6 +11,7 @@ import com.monari.monariback.study.dto.StudyDto;
 import com.monari.monariback.study.dto.request.StudyChangeStatusRequest;
 import com.monari.monariback.study.dto.request.StudyCreateRequest;
 import com.monari.monariback.study.dto.request.StudyEditRequest;
+import com.monari.monariback.study.dto.request.StudySearchRequest;
 import com.monari.monariback.study.dto.response.StudyDetailResponse;
 import com.monari.monariback.study.dto.response.StudyResponse;
 import com.monari.monariback.study.entity.Study;
@@ -48,6 +49,7 @@ public class StudyService {
                 request.description(),
                 request.subject(),
                 request.schoolLevel(),
+                request.region(),
                 location,
                 student
         );
@@ -77,24 +79,38 @@ public class StudyService {
     /**
      * 스터디 검색 기반 페이지별 목록 조회
      * 최신순 정렬
-     * @param pageNum - 페이지 번호
-     * @param pageSize - 한 페이지에 조회될 스터디 개수
-     * @param titleKeyword - 제목 키워드
-     * @param descriptionKeyword - 설명 키워드
+     * @param int pageNum - 페이지 번호
+     * @param int pageSize - 한 페이지에 조회될 스터디 개수
+     * @param String titleKeyword - 제목 키워드
+     * @param String descriptionKeyword - 설명 키워드
+     * @param SchoolLevel schoolLevel, - 학교급
+     * @param Subject subject, - 과목
+     * @param Region region - 지역구
      * @return Page<StudyResponse>
      * @author Jeong
      */
     @Transactional(readOnly = true)
-    public Page<StudyResponse> searchStudies(final int pageNum,
-                                             final int pageSize,
-                                             final String titleKeyword,
-                                             final String descriptionKeyword) {
-        List<StudyDto> studies = studyRepository.findByKeywordOrderByCreatedAtDesc(pageNum, pageSize, titleKeyword, descriptionKeyword);
+    public Page<StudyResponse> searchStudies(final int pageNum, final int pageSize, final StudySearchRequest request) {
+        List<StudyDto> studies = studyRepository.findByKeywordsOrderByCreatedAtDesc(
+                pageNum,
+                pageSize,
+                request.titleKeyword(),
+                request.descriptionKeyword(),
+                request.schoolLevel(),
+                request.subject(),
+                request.region()
+        );
         List<StudyResponse> content = studies.stream()
                 .map(StudyResponse::from)
                 .toList();
 
-        long totalStudyCount = studyRepository.countByKeyword(titleKeyword, descriptionKeyword);
+        long totalStudyCount = studyRepository.countByKeywords(
+                request.titleKeyword(),
+                request.descriptionKeyword(),
+                request.schoolLevel(),
+                request.subject(),
+                request.region()
+        );
 
         return new PageImpl<>(
                 content, PageRequest.of(pageNum - 1, pageSize), totalStudyCount

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -192,27 +192,28 @@ VALUES (1, 1, '고등수학 미적분 심화 과정', '미적분의 개념부터
 -- Location ID 1-10 사용 가정
 INSERT INTO study (title, description, subject, school_level, status, location_id, student_id,
                    created_at,
-                   updated_at)
+                   updated_at,
+                   region)
 VALUES ('고등수학 스터디 - 미적분 문제풀이', '매주 모여 미적분 심화 문제를 함께 풀이합니다.', 'MATH', 'HIGH', 'ACTIVE', 1, 2,
-        CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+        CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 'GEUMCHEON_GU'),
        ('물리 스터디 - 역학 집중 탐구', '뉴턴 역학 중심으로 개념 이해 및 문제 해결 능력 향상.', 'SCIENCE', 'HIGH', 'ACTIVE', 2, 3,
-        CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+        CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 'GEUMCHEON_GU'),
        ('중학수학 내신 대비 스터디', '학교 시험 범위 맞춰 개념 정리 및 문제 풀이 진행.', 'MATH', 'MIDDLE', 'CLOSED', 3, 4,
-        CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+        CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 'GANGBUK_GU'),
        ('화학 반응식 완전 정복', '다양한 화학 반응식을 이해하고 암기하는 스터디.', 'SCIENCE', 'HIGH', 'ACTIVE', 7, 1,
-        CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+        CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 'MAPO_GU'),
        ('생명과학 토론 스터디', '최신 생명과학 이슈에 대해 토론하고 발표합니다.', 'SCIENCE', 'HIGH', 'ACTIVE', 9, 6,
-        CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+        CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 'MAPO_GU'),
        ('확률과 통계 개념 완성', '확률과 통계 기본 개념부터 응용까지 함께 공부합니다.', 'MATH', 'HIGH', 'ACTIVE', 5, 8,
-        CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+        CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 'SEOCHO_GU'),
        ('과학 실험 보고서 작성법', '실험 설계부터 결과 분석, 보고서 작성까지 연습합니다.', 'SCIENCE', 'MIDDLE', 'ACTIVE', 7, 8,
-        CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+        CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 'MAPO_GU'),
        ('수학 경시대회 준비 모임', '고난도 수학 문제 풀이 및 전략 공유.', 'MATH', 'HIGH', 'CLOSED', 1, 10,
-        CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+        CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 'GEUMCHEON_GU'),
        ('중학 과학 개념 노트 정리', '과학 교과서 핵심 내용을 함께 정리하고 복습합니다.', 'SCIENCE', 'MIDDLE', 'ACTIVE', 3, 5,
-        CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+        CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 'GEUMCHEON_GU'),
        ('물리 심화 문제 도전', '물리 올림피아드 수준의 문제 풀이에 도전합니다.', 'SCIENCE', 'HIGH', 'ACTIVE', 2, 1,
-        CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+        CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 'GANGBUK_GU');
 
 
 -- Enrollment 테이블 더미 데이터 삽입


### PR DESCRIPTION
## 관련 이슈

> #58 

## 작업 내용
- Study 엔티티 및 DTO에 Region 필드 추가
- 대상, 과목, 지역구 포함 다중 쿼리 파라미터 DTO로 생성
- Study Request DTO 유효성 검증 값 상수로 관리

## ETC
종민 님이 Lesson 엔티티에 Region 필드 따로 두셔서 저도 Study 엔티티에 Region 필드 추가해서 Study 저장할 때 사용자에게서 입력받는 식으로 했습니다. 

