### PR TITLE
[리펙토링] redirect-uri 환경 변수로 분리 및 CI/CD 설정 파일 수정

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -26,8 +26,10 @@ jobs:
         env:
           SEOUL_API_KEY: ${{ secrets.SEOUL_API_KEY }}
           KAKAO_CLIENT_ID: ${{ secrets.KAKAO_CLIENT_ID }}
+          KAKAO_REDIRECT_URI: ${{ secrets.KAKAO_REDIRECT_URI }}
           GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
           GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
+          GOOGLE_REDIRECT_URI: ${{ secrets.GOOGLE_REDIRECT_URI }}
           JWT_SECRET_KEY: ${{ secrets.JWT_SECRET_KEY }}
         run: ./gradlew clean build
 
@@ -70,8 +72,10 @@ jobs:
             cat <<EOF > .env
             SEOUL_API_KEY=${{ secrets.SEOUL_API_KEY }}
             KAKAO_CLIENT_ID=${{ secrets.KAKAO_CLIENT_ID }}
+            KAKAO_REDIRECT_URI=${{ secrets.KAKAO_REDIRECT_URI }}
             GOOGLE_CLIENT_ID=${{ secrets.GOOGLE_CLIENT_ID }}
             GOOGLE_CLIENT_SECRET=${{ secrets.GOOGLE_CLIENT_SECRET }}
+            GOOGLE_REDIRECT_URI=${{ secrets.GOOGLE_REDIRECT_URI }}
             JWT_SECRET_KEY=${{ secrets.JWT_SECRET_KEY }}
             EOF
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -30,14 +30,14 @@ location:
 oauth:
   kakao:
     client-id: ${KAKAO_CLIENT_ID}
-    redirect-uri: http://localhost:3000/auth/kakao/callback
+    redirect-uri: ${KAKAO_REDIRECT_URI}
     token-uri: https://kauth.kakao.com/oauth/token
     user-info-uri: https://kapi.kakao.com/v2/user/me
 
   google:
     client-id: ${GOOGLE_CLIENT_ID}
     client-secret: ${GOOGLE_CLIENT_SECRET}
-    redirect-uri: http://localhost:3000/auth/google/callback
+    redirect-uri: ${GOOGLE_REDIRECT_URI}
     token-uri: https://oauth2.googleapis.com/token
     user-info-uri: https://www.googleapis.com/oauth2/v2/userinfo
 


### PR DESCRIPTION
## 관련 이슈

> #68 

## 작업 내용
- 소셜 로그인(Google, Kakao) `redirect-uri` 값을 `application.yml`에서 직접 지정하던 방식에서 **환경 변수**로 분리
  - `KAKAO_REDIRECT_URI`, `GOOGLE_REDIRECT_URI`로 환경별 유연한 설정 가능
- CI/CD 자동 배포 환경에서도 `.yml` 내 `redirect-uri`가 하드코딩되지 않도록 수정
- 관련 `.env`, GitHub Actions secrets 등에서도 연동되도록 고려

## ETC
> 관련 링크 또는 참고 사항  
- 환경 변수 설정 예시
  ```env
  KAKAO_REDIRECT_URI=https://monari.site/auth/kakao/callback  
  GOOGLE_REDIRECT_URI=https://monari.site/auth/google/callback
  ```
- 추후 `application-prod.yml`, `application-local.yml` 등 프로파일 별 설정 분리 시에도 유지보수가 쉬워짐  