### PR TITLE
[리펙토링] yml profile 분리  (local, prod)

### DIFF
--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -2,8 +2,6 @@ spring:
   config:
     activate:
       on-profile: local
-  application:
-    name: monari-back
   jpa:
     hibernate:
       ddl-auto: create-drop
@@ -20,31 +18,17 @@ spring:
     url: jdbc:h2:mem:test
     username: sa
     password:
-  api:
-    base-url: http://openAPI.seoul.go.kr:8088
-    key: ${SEOUL_API_KEY}
-    service-name: ListPublicReservationInstitution
-    data-type: json
-
-location:
-  init: true
-
 
 oauth:
   kakao:
     client-id: ${KAKAO_CLIENT_ID}
-    redirect-uri: ${KAKAO_REDIRECT_URI}
+    redirect-uri: http://localhost:3000/auth/kakao/callback
     token-uri: https://kauth.kakao.com/oauth/token
     user-info-uri: https://kapi.kakao.com/v2/user/me
 
   google:
     client-id: ${GOOGLE_CLIENT_ID}
     client-secret: ${GOOGLE_CLIENT_SECRET}
-    redirect-uri: ${GOOGLE_REDIRECT_URI}
+    redirect-uri: http://localhost:3000/auth/google/callback
     token-uri: https://oauth2.googleapis.com/token
     user-info-uri: https://www.googleapis.com/oauth2/v2/userinfo
-
-
-jwt:
-  secret-key: ${JWT_SECRET_KEY}
-  accessToken-expiration-millis: 1800000

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -2,8 +2,6 @@ spring:
   config:
     activate:
       on-profile: prod
-  application:
-    name: monari-back
   jpa:
     hibernate:
       ddl-auto: update
@@ -13,31 +11,17 @@ spring:
     password: ${DB_PASSWORD}
     username: ${DB_USERNAME}
     driver-class-name: com.mysql.cj.jdbc.Driver
-  api:
-    base-url: http://openAPI.seoul.go.kr:8088
-    key: ${SEOUL_API_KEY}
-    service-name: ListPublicReservationInstitution
-    data-type: json
-
-location:
-  init: true
-
 
 oauth:
   kakao:
     client-id: ${KAKAO_CLIENT_ID}
-    redirect-uri: http://localhost:3000/auth/kakao/callback
+    redirect-uri: ${KAKAO_REDIRECT_URI}
     token-uri: https://kauth.kakao.com/oauth/token
     user-info-uri: https://kapi.kakao.com/v2/user/me
 
   google:
     client-id: ${GOOGLE_CLIENT_ID}
     client-secret: ${GOOGLE_CLIENT_SECRET}
-    redirect-uri: http://localhost:3000/auth/google/callback
+    redirect-uri: ${GOOGLE_REDIRECT_URI}
     token-uri: https://oauth2.googleapis.com/token
     user-info-uri: https://www.googleapis.com/oauth2/v2/userinfo
-
-
-jwt:
-  secret-key: ${JWT_SECRET_KEY}
-  accessToken-expiration-millis: 1800000

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,17 @@
+spring:
+  profiles:
+    active: ${SPRING_PROFILES_ACTIVE}
+  application:
+    name: monari-back
+  api:
+    base-url: http://openAPI.seoul.go.kr:8088
+    key: ${SEOUL_API_KEY}
+    service-name: ListPublicReservationInstitution
+    data-type: json
+
+location:
+  init: true
+
+jwt:
+  secret-key: ${JWT_SECRET_KEY}
+  accessToken-expiration-millis: 1800000


### PR DESCRIPTION
## 작업 내용
- 공통 설정은 `application.yml`에 유지하고, 환경별로 달라지는 설정을 `application-local.yml`과 `application-prod.yml`로 분리함  
  - **공통 설정**: 애플리케이션 이름, 공통 API 설정, JWT 관련 설정 등
  - **개발 환경(local)**: H2 데이터베이스, `ddl-auto: create-drop`, H2 콘솔 활성화, 로컬 환경용 소셜 로그인 리다이렉션 등
  - **운영 환경(prod)**: MySQL 데이터베이스 연결, `ddl-auto: update`, 운영 환경용 소셜 로그인 리다이렉션 등
- 프로파일 활성화는 `spring.profiles.active` 설정을 통해 관리하도록 함  
  - 예시: 로컬에서는 `dev` 혹은 `local`, 운영 환경에서는 `prod` 지정
- 이를 통해 환경별 설정을 명확하게 분리하여 관리 효율성과 유지보수성을 향상시킴

## ETC
> 참고할만한 링크 또는 메모  
> - [Spring Boot 공식 문서 - 프로파일](https://docs.spring.io/spring-boot/docs/current/reference/html/features.html#features.profiles)  
> - [Spring Boot Externalized Configuration](https://docs.spring.io/spring-boot/docs/current/reference/html/spring-boot-features.html#boot-features-external-config)

