### PR TITLE
[Location] 서울시 공공 API 배치처리

### DIFF
--- a/src/main/java/com/monari/monariback/batch/config/LessonFeeJobConfig.java
+++ b/src/main/java/com/monari/monariback/batch/config/LessonFeeJobConfig.java
@@ -1,9 +1,9 @@
 package com.monari.monariback.batch.config;
 
-import com.monari.monariback.batch.itemprocessor.MailItemProcessor;
-import com.monari.monariback.batch.itemprocessor.LessonItemProcessor;
-import com.monari.monariback.batch.itemwriter.EnrollmentItemWriter;
 import com.monari.monariback.batch.dto.LessonFeeDto;
+import com.monari.monariback.batch.itemprocessor.LessonItemProcessor;
+import com.monari.monariback.batch.itemprocessor.MailItemProcessor;
+import com.monari.monariback.batch.itemwriter.EnrollmentItemWriter;
 import com.monari.monariback.enrollment.entity.Enrollment;
 import com.monari.monariback.lesson.entity.Lesson;
 import jakarta.mail.internet.MimeMessage;
@@ -100,18 +100,18 @@ public class LessonFeeJobConfig {
 
     @Bean
     public Step lessonFeeNotificationStep(JobRepository jobRepository,
-                                          PlatformTransactionManager transactionManager,
-                                          JpaPagingItemReader<Enrollment> enrollmentItemReader,
-                                          MimeMessageItemWriter mimeMessageItemWriter) {
+        PlatformTransactionManager transactionManager,
+        JpaPagingItemReader<Enrollment> enrollmentItemReader,
+        MimeMessageItemWriter mimeMessageItemWriter) {
         return new StepBuilder("lessonFeeNotificationStep", jobRepository)
-                .<Enrollment, MimeMessage>chunk(10, transactionManager)
-                .reader(enrollmentItemReader)
-                .processor(mailItemProcessor)
-                .writer(mimeMessageItemWriter)
-                .build();
+            .<Enrollment, MimeMessage>chunk(10, transactionManager)
+            .reader(enrollmentItemReader)
+            .processor(mailItemProcessor)
+            .writer(mimeMessageItemWriter)
+            .build();
     }
 
-    @Bean
+    @Bean(name = "lessonFeeJob")
     public Job lessonFeeJob(JobRepository jobRepository,
         @Qualifier("lessonFeeCalculationStep") Step lessonFeeCalculationStep,
         @Qualifier("lessonFeeNotificationStep") Step lessonFeeNotificationStep) {

--- a/src/main/java/com/monari/monariback/batch/config/PublicApiJobConfig.java
+++ b/src/main/java/com/monari/monariback/batch/config/PublicApiJobConfig.java
@@ -4,6 +4,7 @@ import com.monari.monariback.batch.itemReader.PublicApiDataReader;
 import com.monari.monariback.batch.itemprocessor.PublicApiDataProcessor;
 import com.monari.monariback.batch.itemwriter.PublicApiDataWriter;
 import com.monari.monariback.location.dto.OpenApiLocationDto;
+import com.monari.monariback.location.entity.Location;
 import lombok.RequiredArgsConstructor;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.Step;
@@ -38,7 +39,7 @@ public class PublicApiJobConfig {
     public Step publicDataStep(JobRepository jobRepository,
         PlatformTransactionManager transactionManager) {
         return new StepBuilder("publicDataStep", jobRepository)
-            .<OpenApiLocationDto, OpenApiLocationDto>chunk(10, transactionManager)
+            .<OpenApiLocationDto, Location>chunk(10, transactionManager)
             .reader(publicApiDataReader)
             .processor(publicApiDataProcessor)
             .writer(publicApiDataWriter)

--- a/src/main/java/com/monari/monariback/batch/config/PublicApiJobConfig.java
+++ b/src/main/java/com/monari/monariback/batch/config/PublicApiJobConfig.java
@@ -28,16 +28,16 @@ public class PublicApiJobConfig {
 
     @Bean(name = "publicDataSyncJob")
     public Job publicDataSyncJob(JobRepository jobRepository,
-        @Qualifier("getApiData") Step getApiData) {
+        @Qualifier("publicDataStep") Step getApiData) {
         return new JobBuilder("publicDataSyncJob", jobRepository)
             .start(getApiData)
             .build();
     }
 
     @Bean
-    public Step getApiData(JobRepository jobRepository,
+    public Step publicDataStep(JobRepository jobRepository,
         PlatformTransactionManager transactionManager) {
-        return new StepBuilder("syncStep", jobRepository)
+        return new StepBuilder("publicDataStep", jobRepository)
             .<OpenApiLocationDto, OpenApiLocationDto>chunk(10, transactionManager)
             .reader(publicApiDataReader)
             .processor(publicApiDataProcessor)

--- a/src/main/java/com/monari/monariback/batch/config/PublicApiJobConfig.java
+++ b/src/main/java/com/monari/monariback/batch/config/PublicApiJobConfig.java
@@ -1,0 +1,47 @@
+package com.monari.monariback.batch.config;
+
+import com.monari.monariback.batch.itemReader.PublicApiDataReader;
+import com.monari.monariback.batch.itemprocessor.PublicApiDataProcessor;
+import com.monari.monariback.batch.itemwriter.PublicApiDataWriter;
+import com.monari.monariback.location.dto.OpenApiLocationDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@Configuration
+@EnableBatchProcessing(tablePrefix = "batch.BATCH_")
+@RequiredArgsConstructor
+public class PublicApiJobConfig {
+
+
+    private final PublicApiDataReader publicApiDataReader;
+    private final PublicApiDataWriter publicApiDataWriter;
+    private final PublicApiDataProcessor publicApiDataProcessor;
+
+    @Bean(name = "publicDataSyncJob")
+    public Job publicDataSyncJob(JobRepository jobRepository,
+        @Qualifier("getApiData") Step getApiData) {
+        return new JobBuilder("publicDataSyncJob", jobRepository)
+            .start(getApiData)
+            .build();
+    }
+
+    @Bean
+    public Step getApiData(JobRepository jobRepository,
+        PlatformTransactionManager transactionManager) {
+        return new StepBuilder("syncStep", jobRepository)
+            .<OpenApiLocationDto, OpenApiLocationDto>chunk(10, transactionManager)
+            .reader(publicApiDataReader)
+            .processor(publicApiDataProcessor)
+            .writer(publicApiDataWriter)
+            .build();
+    }
+}

--- a/src/main/java/com/monari/monariback/batch/itemReader/PublicApiDataReader.java
+++ b/src/main/java/com/monari/monariback/batch/itemReader/PublicApiDataReader.java
@@ -1,0 +1,49 @@
+package com.monari.monariback.batch.itemReader;
+
+import com.monari.monariback.location.config.LocationApiProperties;
+import com.monari.monariback.location.dto.OpenApiLocationDto;
+import com.monari.monariback.location.dto.response.OpenApiLocationResponse;
+import com.monari.monariback.location.util.WebClientUtil;
+import java.util.Iterator;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.item.ItemReader;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PublicApiDataReader implements ItemReader<OpenApiLocationDto> {
+
+    private static final String CATEGORY = "강의실";
+    private static final int START = 1;
+    private static final int TOTAL_COUNT = 100;
+    private final LocationApiProperties apiProperties;
+    private final WebClientUtil webClientUtil;
+    private Iterator<OpenApiLocationDto> iterator;
+
+    private List<OpenApiLocationDto> fetchDataFromApi() {
+        OpenApiLocationResponse responseDto = webClientUtil.get(
+            webClientUtil.buildRequestUri(
+                apiProperties.getBaseUrl(),
+                apiProperties.getKey(),
+                apiProperties.getDataType(),
+                apiProperties.getServiceName(),
+                CATEGORY,
+                START,
+                TOTAL_COUNT),
+            OpenApiLocationResponse.class);
+
+        return responseDto.listPublicReservationInstitution().row().stream().toList();
+    }
+
+    @Override
+    public OpenApiLocationDto read() {
+        if (iterator == null) {
+            List<OpenApiLocationDto> data = fetchDataFromApi();
+            iterator = data.iterator();
+        }
+        return iterator.hasNext() ? iterator.next() : null;
+    }
+}

--- a/src/main/java/com/monari/monariback/batch/itemReader/PublicApiDataReader.java
+++ b/src/main/java/com/monari/monariback/batch/itemReader/PublicApiDataReader.java
@@ -23,6 +23,12 @@ public class PublicApiDataReader implements ItemReader<OpenApiLocationDto> {
     private final WebClientUtil webClientUtil;
     private Iterator<OpenApiLocationDto> iterator;
 
+    /**
+     * 외부 공공 API에서 데이터를 조회하고, DTO 리스트로 반환하는 내부 메서드
+     *
+     * @return OpenApiLocationDto 리스트
+     * @author Hong
+     */
     private List<OpenApiLocationDto> fetchDataFromApi() {
         OpenApiLocationResponse responseDto = webClientUtil.get(
             webClientUtil.buildRequestUri(
@@ -38,6 +44,12 @@ public class PublicApiDataReader implements ItemReader<OpenApiLocationDto> {
         return responseDto.listPublicReservationInstitution().row().stream().toList();
     }
 
+    /**
+     * Spring Batch가 데이터를 읽을 때 호출되는 메서드. 처음 한 번 API로부터 전체 데이터를 가져오고, 이후 한 개씩 반환.
+     *
+     * @return 다음 OpenApiLocationDto 객체 또는 더 이상 없으면 null
+     * @author Hong
+     */
     @Override
     public OpenApiLocationDto read() {
         if (iterator == null) {

--- a/src/main/java/com/monari/monariback/batch/itemprocessor/PublicApiDataProcessor.java
+++ b/src/main/java/com/monari/monariback/batch/itemprocessor/PublicApiDataProcessor.java
@@ -1,0 +1,21 @@
+package com.monari.monariback.batch.itemprocessor;
+
+import com.monari.monariback.location.dto.OpenApiLocationDto;
+import com.monari.monariback.location.repository.LocationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class PublicApiDataProcessor implements
+    ItemProcessor<OpenApiLocationDto, OpenApiLocationDto> {
+
+    private final LocationRepository locationRepository;
+
+    @Override
+    public OpenApiLocationDto process(OpenApiLocationDto item) {
+        boolean exists = locationRepository.existsByServiceId(item.svcId());
+        return exists ? null : item;
+    }
+}

--- a/src/main/java/com/monari/monariback/batch/itemprocessor/PublicApiDataProcessor.java
+++ b/src/main/java/com/monari/monariback/batch/itemprocessor/PublicApiDataProcessor.java
@@ -5,14 +5,23 @@ import com.monari.monariback.location.repository.LocationRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.batch.item.ItemProcessor;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 @Component
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class PublicApiDataProcessor implements
     ItemProcessor<OpenApiLocationDto, OpenApiLocationDto> {
 
     private final LocationRepository locationRepository;
 
+    /**
+     * 외부 API에서 가져온 OpenApiLocationDto가 DB에 이미 존재하는지 확인하고, 존재하지 않는 경우에만 해당 데이터를 다음 단계로 넘긴다.
+     *
+     * @param item OpenApiLocationDto 객체 (API에서 읽어온 하나의 데이터)
+     * @return 기존에 존재하면 null, 존재하지 않으면 해당 item 반환
+     * @author Hong
+     */
     @Override
     public OpenApiLocationDto process(OpenApiLocationDto item) {
         boolean exists = locationRepository.existsByServiceId(item.svcId());

--- a/src/main/java/com/monari/monariback/batch/itemprocessor/PublicApiDataProcessor.java
+++ b/src/main/java/com/monari/monariback/batch/itemprocessor/PublicApiDataProcessor.java
@@ -1,7 +1,9 @@
 package com.monari.monariback.batch.itemprocessor;
 
 import com.monari.monariback.location.dto.OpenApiLocationDto;
+import com.monari.monariback.location.entity.Location;
 import com.monari.monariback.location.repository.LocationRepository;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.batch.item.ItemProcessor;
 import org.springframework.stereotype.Component;
@@ -9,9 +11,9 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Component
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
+@Transactional
 public class PublicApiDataProcessor implements
-    ItemProcessor<OpenApiLocationDto, OpenApiLocationDto> {
+    ItemProcessor<OpenApiLocationDto, Location> {
 
     private final LocationRepository locationRepository;
 
@@ -19,12 +21,51 @@ public class PublicApiDataProcessor implements
      * 외부 API에서 가져온 OpenApiLocationDto가 DB에 이미 존재하는지 확인하고, 존재하지 않는 경우에만 해당 데이터를 다음 단계로 넘긴다.
      *
      * @param item OpenApiLocationDto 객체 (API에서 읽어온 하나의 데이터)
-     * @return 기존에 존재하면 null, 존재하지 않으면 해당 item 반환
+     * @return 기존에 존재하면 해당 Location 업데이트 후 반환, 존재하지 않으면 새 Location 반환
      * @author Hong
      */
     @Override
-    public OpenApiLocationDto process(OpenApiLocationDto item) {
-        boolean exists = locationRepository.existsByServiceId(item.svcId());
-        return exists ? null : item;
+    public Location process(OpenApiLocationDto item) {
+        Optional<Location> existingLocation = locationRepository.findByServiceId(item.svcId());
+
+        if (existingLocation.isPresent()) {
+            Location location = existingLocation.get();
+            if (location.updateIfChanged(
+                item.minClassNm(),
+                item.svcStatNm(),
+                item.payAtNm(),
+                item.placeNm(),
+                item.svcUrl(),
+                item.svcOpnBgndt(),
+                item.svcOpnEnddt(),
+                item.rcptBgndt(),
+                item.rcptEnddt(),
+                item.revStdDayNm(),
+                item.revStdDay(),
+                item.x(),
+                item.y())
+            ) {
+                return location;
+            }
+        } else {
+            return Location.ofCreate(
+                item.svcId(),
+                item.minClassNm(),
+                item.svcStatNm(),
+                item.payAtNm(),
+                item.placeNm(),
+                item.svcUrl(),
+                item.svcOpnBgndt(),
+                item.svcOpnEnddt(),
+                item.rcptBgndt(),
+                item.rcptEnddt(),
+                item.revStdDayNm(),
+                item.revStdDay(),
+                item.x(),
+                item.y()
+            );
+        }
+
+        return null; // 변경되지 않았거나 처리할 데이터가 없다면 null 반환
     }
 }

--- a/src/main/java/com/monari/monariback/batch/itemwriter/PublicApiDataWriter.java
+++ b/src/main/java/com/monari/monariback/batch/itemwriter/PublicApiDataWriter.java
@@ -1,0 +1,44 @@
+package com.monari.monariback.batch.itemwriter;
+
+import com.monari.monariback.location.dto.OpenApiLocationDto;
+import com.monari.monariback.location.entity.Location;
+import com.monari.monariback.location.repository.LocationRepository;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.item.Chunk;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class PublicApiDataWriter implements ItemWriter<OpenApiLocationDto> {
+
+    private final LocationRepository locationRepository;
+
+    @Override
+    public void write(Chunk<? extends OpenApiLocationDto> items) {
+        List<Location> entities = items.getItems()
+            .stream()
+            .map(data -> Location.ofCreate(
+                    data.svcId(),
+                    data.minClassNm(),
+                    data.svcStatNm(),
+                    data.payAtNm(),
+                    data.placeNm(),
+                    data.svcUrl(),
+                    data.svcOpnBgndt(),
+                    data.svcOpnEnddt(),
+                    data.rcptBgndt(),
+                    data.rcptEnddt(),
+                    data.revStdDayNm(),
+                    data.revStdDay(),
+                    data.x(),
+                    data.y()
+                )
+            )
+            .collect(Collectors.toList());
+
+        locationRepository.saveAll(entities);
+    }
+}

--- a/src/main/java/com/monari/monariback/batch/itemwriter/PublicApiDataWriter.java
+++ b/src/main/java/com/monari/monariback/batch/itemwriter/PublicApiDataWriter.java
@@ -1,10 +1,7 @@
 package com.monari.monariback.batch.itemwriter;
 
-import com.monari.monariback.location.dto.OpenApiLocationDto;
 import com.monari.monariback.location.entity.Location;
 import com.monari.monariback.location.repository.LocationRepository;
-import java.util.List;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.batch.item.Chunk;
 import org.springframework.batch.item.ItemWriter;
@@ -14,39 +11,18 @@ import org.springframework.transaction.annotation.Transactional;
 @Component
 @RequiredArgsConstructor
 @Transactional
-public class PublicApiDataWriter implements ItemWriter<OpenApiLocationDto> {
+public class PublicApiDataWriter implements ItemWriter<Location> {
 
     private final LocationRepository locationRepository;
 
     /**
      * Spring Batch에서 한 번에 쓰여질 데이터(Chunk 단위)를 받아, Entity로 변환 후 Repository를 통해 저장.
      *
-     * @param items OpenApiLocationDto 목록
+     * @param locations Location 목록
      * @author Hong
      */
     @Override
-    public void write(Chunk<? extends OpenApiLocationDto> items) {
-        List<Location> entities = items.getItems()
-            .stream()
-            .map(data -> Location.ofCreate(
-                    data.svcId(),
-                    data.minClassNm(),
-                    data.svcStatNm(),
-                    data.payAtNm(),
-                    data.placeNm(),
-                    data.svcUrl(),
-                    data.svcOpnBgndt(),
-                    data.svcOpnEnddt(),
-                    data.rcptBgndt(),
-                    data.rcptEnddt(),
-                    data.revStdDayNm(),
-                    data.revStdDay(),
-                    data.x(),
-                    data.y()
-                )
-            )
-            .collect(Collectors.toList());
-
-        locationRepository.saveAll(entities);
+    public void write(Chunk<? extends Location> locations) {
+        locationRepository.saveAll(locations.getItems());
     }
 }

--- a/src/main/java/com/monari/monariback/batch/itemwriter/PublicApiDataWriter.java
+++ b/src/main/java/com/monari/monariback/batch/itemwriter/PublicApiDataWriter.java
@@ -9,13 +9,21 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.batch.item.Chunk;
 import org.springframework.batch.item.ItemWriter;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 @Component
 @RequiredArgsConstructor
+@Transactional
 public class PublicApiDataWriter implements ItemWriter<OpenApiLocationDto> {
 
     private final LocationRepository locationRepository;
 
+    /**
+     * Spring Batch에서 한 번에 쓰여질 데이터(Chunk 단위)를 받아, Entity로 변환 후 Repository를 통해 저장.
+     *
+     * @param items OpenApiLocationDto 목록
+     * @author Hong
+     */
     @Override
     public void write(Chunk<? extends OpenApiLocationDto> items) {
         List<Location> entities = items.getItems()

--- a/src/main/java/com/monari/monariback/batch/scheduler/LessonFeeJobScheduler.java
+++ b/src/main/java/com/monari/monariback/batch/scheduler/LessonFeeJobScheduler.java
@@ -1,33 +1,37 @@
 package com.monari.monariback.batch.scheduler;
 
-import lombok.RequiredArgsConstructor;
+import java.time.LocalDate;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.JobParameters;
 import org.springframework.batch.core.JobParametersBuilder;
 import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
-import java.time.LocalDate;
-
 @Slf4j
 @Component
-@RequiredArgsConstructor
 public class LessonFeeJobScheduler {
 
     private final JobLauncher jobLauncher;
+
     private final Job lessonFeeJob;
 
+    public LessonFeeJobScheduler(JobLauncher jobLauncher,
+        @Qualifier("lessonFeeJob") Job lessonFeeJob) {
+        this.jobLauncher = jobLauncher;
+        this.lessonFeeJob = lessonFeeJob;
+    }
+
     /**
-     * 최종 수강료 계산 후 DB 쓰기 작업 및 수강료 안내 메일 전송 배치 작업 스케줄링
-     * 매일 24시 10분 수업 시작일이 된 수업을 대상으로 진행
+     * 최종 수강료 계산 후 DB 쓰기 작업 및 수강료 안내 메일 전송 배치 작업 스케줄링 매일 24시 10분 수업 시작일이 된 수업을 대상으로 진행
      */
     @Scheduled(cron = "0 10 0 * * *", zone = "Asia/Seoul")
     public void launchLessonFeeJob() throws Exception {
         JobParameters jobParameters = new JobParametersBuilder()
-                .addLocalDate("lessonStartDate", LocalDate.now())
-                .toJobParameters();
+            .addLocalDate("lessonStartDate", LocalDate.now())
+            .toJobParameters();
 
         try {
             jobLauncher.run(lessonFeeJob, jobParameters);

--- a/src/main/java/com/monari/monariback/batch/scheduler/OpenApiJonScheduler.java
+++ b/src/main/java/com/monari/monariback/batch/scheduler/OpenApiJonScheduler.java
@@ -23,7 +23,7 @@ public class OpenApiJonScheduler {
         this.publicDataSyncJob = publicDataSyncJob;
     }
 
-    @Scheduled(initialDelay = 1000, fixedDelay = Long.MAX_VALUE)
+    @Scheduled(cron = "0 21 8,20 * * *", zone = "Asia/Seoul")
     public void runPublicDataJob() throws Exception {
         JobParameters jobParameters = new JobParametersBuilder()
             .addString("openApiStartDate", UUID.randomUUID().toString())

--- a/src/main/java/com/monari/monariback/batch/scheduler/OpenApiJonScheduler.java
+++ b/src/main/java/com/monari/monariback/batch/scheduler/OpenApiJonScheduler.java
@@ -1,0 +1,38 @@
+package com.monari.monariback.batch.scheduler;
+
+import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class OpenApiJonScheduler {
+
+    private final JobLauncher jobLauncher;
+    private final Job publicDataSyncJob;
+
+    public OpenApiJonScheduler(JobLauncher jobLauncher,
+        @Qualifier("publicDataSyncJob") Job publicDataSyncJob) {
+        this.jobLauncher = jobLauncher;
+        this.publicDataSyncJob = publicDataSyncJob;
+    }
+
+    @Scheduled(initialDelay = 1000, fixedDelay = Long.MAX_VALUE)
+    public void runPublicDataJob() throws Exception {
+        JobParameters jobParameters = new JobParametersBuilder()
+            .addString("openApiStartDate", UUID.randomUUID().toString())
+            .toJobParameters();
+
+        try {
+            jobLauncher.run(publicDataSyncJob, jobParameters);
+        } catch (Exception e) {
+            log.error("publicDataSyncJob failed", e);
+        }
+    }
+}

--- a/src/main/java/com/monari/monariback/batch/scheduler/OpenApiJonScheduler.java
+++ b/src/main/java/com/monari/monariback/batch/scheduler/OpenApiJonScheduler.java
@@ -23,7 +23,7 @@ public class OpenApiJonScheduler {
         this.publicDataSyncJob = publicDataSyncJob;
     }
 
-    @Scheduled(cron = "0 21 8,20 * * *", zone = "Asia/Seoul")
+    @Scheduled(cron = "0 25 8,20 * * *", zone = "Asia/Seoul")
     public void runPublicDataJob() throws Exception {
         JobParameters jobParameters = new JobParametersBuilder()
             .addString("openApiStartDate", UUID.randomUUID().toString())

--- a/src/main/java/com/monari/monariback/location/entity/Location.java
+++ b/src/main/java/com/monari/monariback/location/entity/Location.java
@@ -118,4 +118,128 @@ public class Location {
         String v = nullIfBlank(value);
         return v == null ? null : Integer.parseInt(v);
     }
+
+    public boolean updateIfChanged(
+        String serviceSubcategory,
+        String serviceStatus,
+        String paymentMethod,
+        String locationName,
+        String serviceUrl,
+        String registrationStartDateTime,
+        String registrationEndDateTime,
+        String cancellationStartDateTime,
+        String cancellationEndDateTime,
+        String cancellationPolicyInfo,
+        String cancellationDeadline,
+        String x,
+        String y
+    ) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.S");
+        boolean isChanged = false;
+
+        // String 필드 비교
+        String newServiceSubcategory = nullIfBlank(serviceSubcategory);
+        if (this.serviceSubcategory == null && newServiceSubcategory != null ||
+            this.serviceSubcategory != null && !this.serviceSubcategory.equals(
+                newServiceSubcategory)) {
+            this.serviceSubcategory = newServiceSubcategory;
+            isChanged = true;
+        }
+
+        String newServiceStatus = nullIfBlank(serviceStatus);
+        if (this.serviceStatus == null && newServiceStatus != null ||
+            this.serviceStatus != null && !this.serviceStatus.equals(newServiceStatus)) {
+            this.serviceStatus = newServiceStatus;
+            isChanged = true;
+        }
+
+        String newPaymentMethod = nullIfBlank(paymentMethod);
+        if (this.paymentMethod == null && newPaymentMethod != null ||
+            this.paymentMethod != null && !this.paymentMethod.equals(newPaymentMethod)) {
+            this.paymentMethod = newPaymentMethod;
+            isChanged = true;
+        }
+
+        String newLocationName = nullIfBlank(locationName);
+        if (this.locationName == null && newLocationName != null ||
+            this.locationName != null && !this.locationName.equals(newLocationName)) {
+            this.locationName = newLocationName;
+            isChanged = true;
+        }
+
+        String newServiceUrl = nullIfBlank(serviceUrl);
+        if (this.serviceUrl == null && newServiceUrl != null ||
+            this.serviceUrl != null && !this.serviceUrl.equals(newServiceUrl)) {
+            this.serviceUrl = newServiceUrl;
+            isChanged = true;
+        }
+
+        // LocalDateTime 필드 비교
+        LocalDateTime newRegistrationStart = parseDate(registrationStartDateTime, formatter);
+        if (this.registrationStartDateTime == null && newRegistrationStart != null ||
+            this.registrationStartDateTime != null && !this.registrationStartDateTime.equals(
+                newRegistrationStart)) {
+            this.registrationStartDateTime = newRegistrationStart;
+            isChanged = true;
+        }
+
+        LocalDateTime newRegistrationEnd = parseDate(registrationEndDateTime, formatter);
+        if (this.registrationEndDateTime == null && newRegistrationEnd != null ||
+            this.registrationEndDateTime != null && !this.registrationEndDateTime.equals(
+                newRegistrationEnd)) {
+            this.registrationEndDateTime = newRegistrationEnd;
+            isChanged = true;
+        }
+
+        LocalDateTime newCancellationStart = parseDate(cancellationStartDateTime, formatter);
+        if (this.cancellationStartDateTime == null && newCancellationStart != null ||
+            this.cancellationStartDateTime != null && !this.cancellationStartDateTime.equals(
+                newCancellationStart)) {
+            this.cancellationStartDateTime = newCancellationStart;
+            isChanged = true;
+        }
+
+        LocalDateTime newCancellationEnd = parseDate(cancellationEndDateTime, formatter);
+        if (this.cancellationEndDateTime == null && newCancellationEnd != null ||
+            this.cancellationEndDateTime != null && !this.cancellationEndDateTime.equals(
+                newCancellationEnd)) {
+            this.cancellationEndDateTime = newCancellationEnd;
+            isChanged = true;
+        }
+
+        // cancellationPolicyInfo 비교
+        String newCancellationPolicyInfo = nullIfBlank(cancellationPolicyInfo);
+        if (this.cancellationPolicyInfo == null && newCancellationPolicyInfo != null ||
+            this.cancellationPolicyInfo != null && !this.cancellationPolicyInfo.equals(
+                newCancellationPolicyInfo)) {
+            this.cancellationPolicyInfo = newCancellationPolicyInfo;
+            isChanged = true;
+        }
+
+        // Integer 필드 비교
+        Integer newCancellationDeadline = parseInteger(cancellationDeadline);
+        if (this.cancellationDeadline == null && newCancellationDeadline != null ||
+            this.cancellationDeadline != null && !this.cancellationDeadline.equals(
+                newCancellationDeadline)) {
+            this.cancellationDeadline = newCancellationDeadline;
+            isChanged = true;
+        }
+
+        // x, y 비교
+        String newX = nullIfBlank(x);
+        if (this.x == null && newX != null ||
+            this.x != null && !this.x.equals(newX)) {
+            this.x = newX;
+            isChanged = true;
+        }
+
+        String newY = nullIfBlank(y);
+        if (this.y == null && newY != null ||
+            this.y != null && !this.y.equals(newY)) {
+            this.y = newY;
+            isChanged = true;
+        }
+
+        return isChanged;
+    }
 }

--- a/src/main/java/com/monari/monariback/location/entity/Location.java
+++ b/src/main/java/com/monari/monariback/location/entity/Location.java
@@ -25,6 +25,9 @@ public class Location {
     @Column(name = "id")
     private Integer id;
 
+    @Column(name = "service_id", unique = true)
+    private String serviceId;
+
     @Column(name = "service_subcategory")
     private String serviceSubcategory;
 
@@ -66,6 +69,7 @@ public class Location {
 
 
     public static Location ofCreate(
+        final String serviceId,
         final String serviceSubcategory,
         final String serviceStatus,
         final String paymentMethod,
@@ -84,6 +88,7 @@ public class Location {
 
         return new Location(
             null,
+            nullIfBlank(serviceId),
             nullIfBlank(serviceSubcategory),
             nullIfBlank(serviceStatus),
             nullIfBlank(paymentMethod),

--- a/src/main/java/com/monari/monariback/location/repository/LocationRepository.java
+++ b/src/main/java/com/monari/monariback/location/repository/LocationRepository.java
@@ -1,7 +1,6 @@
 package com.monari.monariback.location.repository;
 
 import com.monari.monariback.location.entity.Location;
-import java.util.Set;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -10,5 +9,4 @@ public interface LocationRepository extends JpaRepository<Location, Integer> {
 
     boolean existsByServiceId(String serviceId);
 
-    Set<String> findAllSvcIds();
 }

--- a/src/main/java/com/monari/monariback/location/repository/LocationRepository.java
+++ b/src/main/java/com/monari/monariback/location/repository/LocationRepository.java
@@ -1,12 +1,13 @@
 package com.monari.monariback.location.repository;
 
 import com.monari.monariback.location.entity.Location;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface LocationRepository extends JpaRepository<Location, Integer> {
 
-    boolean existsByServiceId(String serviceId);
+    Optional<Location> findByServiceId(final String serviceId);
 
 }

--- a/src/main/java/com/monari/monariback/location/repository/LocationRepository.java
+++ b/src/main/java/com/monari/monariback/location/repository/LocationRepository.java
@@ -1,10 +1,14 @@
 package com.monari.monariback.location.repository;
 
 import com.monari.monariback.location.entity.Location;
+import java.util.Set;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface LocationRepository extends JpaRepository<Location, Integer> {
 
+    boolean existsByServiceId(String serviceId);
+
+    Set<String> findAllSvcIds();
 }

--- a/src/main/java/com/monari/monariback/location/service/LocationService.java
+++ b/src/main/java/com/monari/monariback/location/service/LocationService.java
@@ -57,6 +57,7 @@ public class LocationService {
 
         return responseDto.listPublicReservationInstitution().row().stream()
             .map(dto -> Location.ofCreate(
+                dto.svcId(),
                 dto.minClassNm(),
                 dto.svcStatNm(),
                 dto.payAtNm(),


### PR DESCRIPTION
## 관련 이슈

> #{ISSUE_NUMBER}

## 작업 내용
- 공공데이터 API 기반 Location 정보 배치 수집 기능 추가
  - `PublicApiDataReader`: 외부 공공 데이터 API 호출하여 강의실 정보 읽어오는 기능 구현
  - `OpenApiLocationDtoProcessor`: 기존 DB에 존재하는 데이터 필터링 처리 (중복 제거)
  - `PublicApiDataWriter`: 읽어온 데이터를 Location 엔티티로 매핑하여 DB에 저장하는 기능 추가
  - 
- OpenApiJobScheduler 작성
  - Spring Batch Job을 스케줄링하여 주기적으로 API 데이터를 동기화
  - 매일 오전 8시 21분, 오후 8시 21분에 Job이 실행되도록 스케줄링 설정


## ETC
> 참고할만한 링크 또는 메모
https://blog.naver.com/ggwaaa2/223847023116


