### PR TITLE
[Lesson] 온라인 오프라인 수업 생성 분기 나누기

### DIFF
--- a/src/main/java/com/monari/monariback/common/enumerated/Region.java
+++ b/src/main/java/com/monari/monariback/common/enumerated/Region.java
@@ -25,5 +25,6 @@ public enum Region {
     EUNPYEONG_GU,
     JONGNO_GU,
     JUNG_GU,
-    JUNGRANG_GU
+    JUNGRANG_GU,
+    ONLINE
 }

--- a/src/main/java/com/monari/monariback/lesson/dto/request/CreateLessonRequest.java
+++ b/src/main/java/com/monari/monariback/lesson/dto/request/CreateLessonRequest.java
@@ -10,14 +10,12 @@ import static com.monari.monariback.lesson.constant.LessonValidationConstants.DE
 import static com.monari.monariback.lesson.constant.LessonValidationConstants.END_DATE_FUTURE;
 import static com.monari.monariback.lesson.constant.LessonValidationConstants.END_DATE_REQUIRED;
 import static com.monari.monariback.lesson.constant.LessonValidationConstants.LOCATION_ID_POSITIVE;
-import static com.monari.monariback.lesson.constant.LessonValidationConstants.LOCATION_ID_REQUIRED;
 import static com.monari.monariback.lesson.constant.LessonValidationConstants.MAX_STUDENT_MIN;
 import static com.monari.monariback.lesson.constant.LessonValidationConstants.MAX_STUDENT_MIN_VALUE;
 import static com.monari.monariback.lesson.constant.LessonValidationConstants.MAX_STUDENT_REQUIRED;
 import static com.monari.monariback.lesson.constant.LessonValidationConstants.MIN_STUDENT_MIN;
 import static com.monari.monariback.lesson.constant.LessonValidationConstants.MIN_STUDENT_MIN_VALUE;
 import static com.monari.monariback.lesson.constant.LessonValidationConstants.MIN_STUDENT_REQUIRED;
-import static com.monari.monariback.lesson.constant.LessonValidationConstants.REGION_REQUIRED;
 import static com.monari.monariback.lesson.constant.LessonValidationConstants.SCHOOL_LEVEL_REQUIRED;
 import static com.monari.monariback.lesson.constant.LessonValidationConstants.START_DATE_FUTURE_OR_PRESENT;
 import static com.monari.monariback.lesson.constant.LessonValidationConstants.START_DATE_REQUIRED;
@@ -45,7 +43,6 @@ import java.time.LocalDate;
 
 public record CreateLessonRequest(
 
-    @NotNull(message = LOCATION_ID_REQUIRED)
     @Positive(message = LOCATION_ID_POSITIVE)
     Integer locationId,
 
@@ -84,7 +81,6 @@ public record CreateLessonRequest(
     @NotNull(message = STATUS_REQUIRED)
     LessonStatus status,
 
-    @NotNull(message = REGION_REQUIRED)
     Region region,
 
     @NotNull(message = SCHOOL_LEVEL_REQUIRED)


### PR DESCRIPTION
## 관련 이슈

> #94 

## 작업 내용
- 온라인/오프라인 수업 생성 로직을 createLesson에서 분기 처리
- createOnlineLesson, createOfflineLesson 메서드로 각각 위임하여 책임 분리
- 온라인 수업은 ONLINE_LOCATION을 이용하고, 지역을 Region.ONLINE으로 고정



## ETC
> 참고할만한 링크 또는 메모

