### PR TITLE
[lesson] 수업 제목, 내용 제목+내용 검색으로 리팩토링

### DIFF
--- a/src/main/java/com/monari/monariback/common/enumerated/SearchType.java
+++ b/src/main/java/com/monari/monariback/common/enumerated/SearchType.java
@@ -1,0 +1,5 @@
+package com.monari.monariback.common.enumerated;
+
+public enum SearchType {
+    TITLE, DESCRIPTION, ALL
+}

--- a/src/main/java/com/monari/monariback/lesson/dto/request/SearchLessonRequest.java
+++ b/src/main/java/com/monari/monariback/lesson/dto/request/SearchLessonRequest.java
@@ -5,6 +5,7 @@ import static com.monari.monariback.lesson.constant.LessonValidationConstants.PA
 
 import com.monari.monariback.common.enumerated.Region;
 import com.monari.monariback.common.enumerated.SchoolLevel;
+import com.monari.monariback.common.enumerated.SearchType;
 import com.monari.monariback.common.enumerated.Subject;
 import com.monari.monariback.lesson.entity.enurmerated.LessonType;
 import jakarta.validation.constraints.Min;
@@ -23,7 +24,8 @@ public record SearchLessonRequest(
     Subject subject,
 
     Region region,
-    LessonType lessonType
+    LessonType lessonType,
+    SearchType searchType
 
 ) {
 

--- a/src/main/java/com/monari/monariback/lesson/repository/LessonCustomRepository.java
+++ b/src/main/java/com/monari/monariback/lesson/repository/LessonCustomRepository.java
@@ -2,6 +2,7 @@ package com.monari.monariback.lesson.repository;
 
 import com.monari.monariback.common.enumerated.Region;
 import com.monari.monariback.common.enumerated.SchoolLevel;
+import com.monari.monariback.common.enumerated.SearchType;
 import com.monari.monariback.common.enumerated.Subject;
 import com.monari.monariback.lesson.entity.Lesson;
 import com.monari.monariback.lesson.entity.enurmerated.LessonType;
@@ -16,14 +17,15 @@ public interface LessonCustomRepository {
 
     List<Lesson> searchLessons(final String keyword, final Integer pageSize, final Integer pageNum,
         final SchoolLevel schoolLevel, final Subject subject, final Region region,
-        final LessonType lessonType);
+        final LessonType lessonType, final SearchType searchType);
 
     int getTotalLessonPages(final int pageSize, final String keyword);
 
     List<Lesson> findAllByTeacherId(final int teacherId, final int pageSize, final int pageNum);
 
     long getTotalLessonCount(final String keyword, final SchoolLevel schoolLevel,
-        final Subject subject, final Region region, final LessonType lessonType);
+        final Subject subject, final Region region, final LessonType lessonType,
+        final SearchType searchType);
 
     Long getTotalLessenByTeacherId(final int teacherId);
 

--- a/src/main/java/com/monari/monariback/lesson/service/LessonService.java
+++ b/src/main/java/com/monari/monariback/lesson/service/LessonService.java
@@ -248,7 +248,8 @@ public class LessonService {
             searchLessonRequest.schoolLevel(),
             searchLessonRequest.subject(),
             searchLessonRequest.region(),
-            searchLessonRequest.lessonType()
+            searchLessonRequest.lessonType(),
+            searchLessonRequest.searchType()
         );
 
         return new PageImpl<>(
@@ -260,7 +261,8 @@ public class LessonService {
                     searchLessonRequest.schoolLevel(),
                     searchLessonRequest.subject(),
                     searchLessonRequest.region(),
-                    searchLessonRequest.lessonType()
+                    searchLessonRequest.lessonType(),
+                    searchLessonRequest.searchType()
                 )
                 .stream()
                 .map(lesson -> {


### PR DESCRIPTION
## 관련 이슈

> #97 

## 작업 내용

SearchType enum 추가 (TITLE, DESCRIPTION, ALL)
SearchLessonRequest에 SearchType searchType 필드 추가
LessonCustomRepositoryImpl 내부 buildKeywordPredicate 및 keywordCondition 메서드 수정
→ searchType에 따라 제목, 내용, 제목+내용 중 선택적으로 검색하도록 변경
fetchLessonsWithPaging, searchLessons 등 전체 검색 로직에서 searchType을 파라미터로 넘기도록 수정
Controller(/search)에서도 searchType을 받을 수 있도록 수정하여 API 요청 시 검색 범위 설정 가능하게 변경

## ETC
> 참고할만한 링크 또는 메모

