### PR TITLE
[lesson] 대용량 페이징 성능 최적화 10만 건 데이터 & 랜덤 페이지 요청 대응하기

### DIFF
--- a/src/main/java/com/monari/monariback/lesson/entity/Lesson.java
+++ b/src/main/java/com/monari/monariback/lesson/entity/Lesson.java
@@ -17,6 +17,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
@@ -31,7 +32,11 @@ import org.hibernate.annotations.BatchSize;
 
 @Entity
 @Getter
-@Table(name = "lesson")
+@Table(name = "lesson",
+    indexes = {
+        @Index(name = "idx_lesson_created_at_id_desc", columnList = "created_at DESC, id DESC")
+    }
+)
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Lesson extends BaseEntity {

--- a/src/main/java/com/monari/monariback/lesson/repository/LessonCustomRepository.java
+++ b/src/main/java/com/monari/monariback/lesson/repository/LessonCustomRepository.java
@@ -35,6 +35,11 @@ public interface LessonCustomRepository {
 
     Integer countTotalLessons();
 
+    //    @Cacheable(
+//        value = "lessons",
+//        key = "'page:' + (#pageNumber != null ? #pageNumber : 1) + ':size:' + (#pageSize != null ? #pageSize : 6)",
+//        unless = "#result == null || #result.isEmpty()"
+//    )
     List<LessonResponse> findLessonsWithStudentCount(
         final Integer pageSize,
         final Integer pageNumber

--- a/src/main/resources/application-perform.yml
+++ b/src/main/resources/application-perform.yml
@@ -1,0 +1,35 @@
+spring:
+  config:
+    activate:
+      on-profile: perform
+  jpa:
+    hibernate:
+      ddl-auto: update  # 필요에 따라 create, validate, none 등으로 변경
+    defer-datasource-initialization: true
+    show-sql: false
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.MySQL8Dialect
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://127.0.0.1:3306/monari?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    username: root
+    password: 1234
+  sql:
+    init:
+      mode: never
+      data-locations: classpath:data-prod.sql
+
+oauth:
+  kakao:
+    client-id: ${KAKAO_CLIENT_ID}
+    redirect-uri: http://localhost:3000/auth/kakao/callback
+    token-uri: https://kauth.kakao.com/oauth/token
+    user-info-uri: https://kapi.kakao.com/v2/user/me
+
+  google:
+    client-id: ${GOOGLE_CLIENT_ID}
+    client-secret: ${GOOGLE_CLIENT_SECRET}
+    redirect-uri: http://localhost:3000/auth/google/callback
+    token-uri: https://oauth2.googleapis.com/token
+    user-info-uri: https://www.googleapis.com/oauth2/v2/userinfo


### PR DESCRIPTION
## 관련 이슈

> #107 

## 작업 내용
- Lesson 조회 API 심각한 성능 이슈(평균 4,345ms 응답시간) 개선
- 서브쿼리 분리 및 JOIN 최적화 기법 적용
- 필요한 ID를 먼저 추출 후 해당 ID에 대해서만 JOIN 및 집계 연산 수행
- 성능 테스트 결과 응답 시간 4,345ms → 23ms로 약 189배 개선
- JPA + QueryDSL 구현에서 2단계 쿼리 방식으로 리팩토링
## 이전
![image](https://github.com/user-attachments/assets/70be22fe-9a28-4154-88f9-50a48702760b)
## 이후
![image](https://github.com/user-attachments/assets/c6fc3478-86dd-4cd6-be2e-9e0911bcea51)

## ETC
>  https://blog.naver.com/ggwaaa2/223861286745

테스트 환경: JMeter 300 요청(랜덤 페이지), Lesson 테이블 10만 데이터
기존 OFFSET-LIMIT 방식의 페이지네이션 구조는 유지하면서 성능 개선

참고 자료: [PostgreSQL Pagination Optimization](https://use-the-index-luke.com/sql/partial-results/fetch-next-page)













